### PR TITLE
M3 — Multiplayer planning loop (protocol v2 + MatchRoom + match server)

### DIFF
--- a/apps/game-server/package.json
+++ b/apps/game-server/package.json
@@ -6,8 +6,10 @@
 	"main": "src/index.ts",
 	"scripts": {
 		"dev": "bun --watch src/index.ts",
+		"dev:match": "bun --watch src/match.ts",
 		"start": "bun src/index.ts",
-		"build": "bun build src/index.ts --compile --outfile dist/game-server",
+		"start:match": "bun src/match.ts",
+		"build": "bun build src/index.ts --compile --outfile dist/game-server && bun build src/match.ts --compile --outfile dist/match-server",
 		"check-types": "tsc --noEmit",
 		"test": "bun test"
 	},

--- a/apps/game-server/src/match.ts
+++ b/apps/game-server/src/match.ts
@@ -1,0 +1,9 @@
+import { createMatchServer } from "./matchServer";
+
+// Entry point for the protocol-V2 match server (the Mechabellum-style loop).
+// The V1 placement-demo server still lives at src/index.ts until the M5 cutover.
+const { server, catalog } = createMatchServer();
+
+console.log(
+	`match-server listening on http://localhost:${server.port} (WebSocket: /ws, protocol v2, catalog ${catalog.hash.slice(0, 12)})`,
+);

--- a/apps/game-server/src/matchRoom.test.ts
+++ b/apps/game-server/src/matchRoom.test.ts
@@ -1,0 +1,331 @@
+import { describe, expect, test } from "bun:test";
+import type { Seat } from "@core/types";
+import { MatchRoom } from "./matchRoom";
+import { testCatalog } from "./testCatalog";
+
+// Deterministic resume tokens so reconnect tests are reproducible.
+function newRoom(id = "m"): MatchRoom {
+	return new MatchRoom(id, testCatalog(), (seat) => `tok-${id}-${seat}`);
+}
+
+/** Seat both players and pick commanders, landing in planning(1). */
+function startMatch(room: MatchRoom, now = 0): void {
+	room.join("p0", "Alice", now);
+	room.join("p1", "Bob", now);
+	expect(room.currentPhase).toBe("commanderPick");
+	const off0 = room.snapshotFor(0).commanderOffers[0];
+	const off1 = room.snapshotFor(1).commanderOffers[0];
+	expect(room.pickCommander("p0", off0, now).ok).toBe(true);
+	expect(room.pickCommander("p1", off1, now).ok).toBe(true);
+	expect(room.currentPhase).toBe("planning");
+	expect(room.currentRound).toBe(1);
+}
+
+describe("MatchRoom — lobby & commander pick", () => {
+	test("stays in lobby until both seats connect", () => {
+		const room = newRoom();
+		room.join("p0", "Alice", 0);
+		expect(room.currentPhase).toBe("lobby");
+		room.join("p1", "Bob", 0);
+		expect(room.currentPhase).toBe("commanderPick");
+	});
+
+	test("rejects a commander that was not offered", () => {
+		const room = newRoom();
+		room.join("p0", "Alice", 0);
+		room.join("p1", "Bob", 0);
+		const r = room.pickCommander("p0", "notARealCommander", 0);
+		expect(r).toMatchObject({ ok: false, code: "unknownCommander" });
+	});
+
+	test("both picks advance to planning(1) and set commander HP", () => {
+		const room = newRoom();
+		startMatch(room);
+		const s0 = room.snapshotFor(0).own;
+		expect(s0.commanderId).not.toBeNull();
+		expect(s0.hp).toBeGreaterThan(0);
+	});
+
+	test("a third player cannot join a full room", () => {
+		const room = newRoom();
+		room.join("p0", "Alice", 0);
+		room.join("p1", "Bob", 0);
+		expect(room.join("p2", "Carol", 0)).toBeNull();
+	});
+});
+
+describe("MatchRoom — economy & planning", () => {
+	test("income is 200*round plus commander mods and starting buildings appear", () => {
+		const room = newRoom();
+		startMatch(room);
+		const own = room.snapshotFor(0).own;
+		// starting cathedral + barracks materialized (buildings are free cards)
+		expect(own.cards.length).toBeGreaterThanOrEqual(2);
+		expect(own.cards.some((c) => c.unitId === "cathedral")).toBe(true);
+		// round-1 income at least 200 (+ startingIncome 200 in base rules)
+		expect(own.coin).toBeGreaterThanOrEqual(200);
+	});
+
+	test("buying a squad spends coin, consumes a deploy, and places a card", () => {
+		const room = newRoom();
+		startMatch(room);
+		const before = room.snapshotFor(0).own;
+		const coin = before.coin;
+		const deploys = before.deploysRemaining;
+		// (0,10) is clear of the seat-0 starting buildings (back line, cols 0-3).
+		const r = room.buySquad("p0", "footman", 0, 10, "north");
+		expect(r.ok).toBe(true);
+		const after = room.snapshotFor(0).own;
+		expect(after.coin).toBe(coin - 100); // footman deployCost
+		expect(after.deploysRemaining).toBe(deploys - 1);
+		expect(after.cards.some((c) => c.unitId === "footman")).toBe(true);
+	});
+
+	test("cannot buy beyond the deploy limit", () => {
+		const room = newRoom();
+		startMatch(room);
+		// deploysPerRound is 2 by default; warlord commander may grant +1.
+		// Place along row 0 (clear of the back-line buildings), spaced by footprint.
+		let bought = 0;
+		let col = 6;
+		for (let i = 0; i < 6; i++) {
+			const r = room.buySquad("p0", "footman", 0, col, "north");
+			col += 6; // footman is 5 wide → space them out to avoid overlap
+			if (r.ok) bought += 1;
+			else {
+				expect(
+					r.code === "noDeploysLeft" || r.code === "insufficientFunds",
+				).toBe(true);
+				break;
+			}
+		}
+		expect(bought).toBeGreaterThanOrEqual(2);
+		expect(room.snapshotFor(0).own.deploysRemaining).toBe(0);
+	});
+
+	test("rejects a placement outside the own half", () => {
+		const room = newRoom();
+		startMatch(room);
+		// seat 0 owns cols 0..23; col 40 is enemy half
+		const r = room.buySquad("p0", "footman", 2, 40, "north");
+		expect(r).toMatchObject({ ok: false, code: "outsideOwnHalf" });
+	});
+
+	test("rejects overlapping placement", () => {
+		const room = newRoom();
+		startMatch(room);
+		expect(room.buySquad("p0", "archer", 0, 10, "north").ok).toBe(true);
+		// archer 4x2 at (0,10) → rows 0..3 cols 10..11; overlap at (1,10)
+		const r = room.buySquad("p0", "archer", 1, 10, "north");
+		expect(r).toMatchObject({ ok: false, code: "tileOccupied" });
+	});
+
+	test("sell refunds and frees a deploy, but only for this round's buys", () => {
+		const room = newRoom();
+		startMatch(room);
+		const buy = room.buySquad("p0", "footman", 0, 10, "north");
+		expect(buy.ok).toBe(true);
+		const card = room
+			.snapshotFor(0)
+			.own.cards.find((c) => c.unitId === "footman" && c.purchasedRound === 1)!;
+		const coinAfterBuy = room.snapshotFor(0).own.coin;
+		const sell = room.sellSquad("p0", card.cardId);
+		expect(sell.ok).toBe(true);
+		expect(room.snapshotFor(0).own.coin).toBe(coinAfterBuy + 100);
+		// cannot sell a starting building (purchasedRound 0)
+		const building = room
+			.snapshotFor(0)
+			.own.cards.find((c) => c.unitId === "cathedral")!;
+		expect(room.sellSquad("p0", building.cardId)).toMatchObject({
+			ok: false,
+			code: "notThisRoundPurchase",
+		});
+	});
+
+	test("unlock gates a locked unit before it can be bought", () => {
+		const room = newRoom();
+		startMatch(room);
+		// ballista has unlockCost 50 → buying before unlock is rejected
+		expect(room.buySquad("p0", "ballista", 0, 10, "north")).toMatchObject({
+			ok: false,
+			code: "notUnlocked",
+		});
+		expect(room.unlockUnit("p0", "ballista").ok).toBe(true);
+		// now buyable (funds permitting)
+		const r = room.buySquad("p0", "ballista", 0, 10, "north");
+		expect(r.ok || r.code === "insufficientFunds").toBe(true);
+	});
+
+	test("buying a tech escalates that unit type's next tech price", () => {
+		const room = newRoom();
+		startMatch(room);
+		// give seat plenty of coin by advancing to a later round isn't trivial;
+		// archer techs are cheap (100/150). Buy the first.
+		const first = room.buyTech("p0", "archer", "archerFireArrows");
+		expect(first.ok || first.code === "insufficientFunds").toBe(true);
+		if (first.ok) {
+			const tech = room.snapshotFor(0).own.tech;
+			expect(tech.purchasedTechs).toContain("archerFireArrows");
+			// escalated price recorded for archer
+			expect(tech.techPriceByUnit.archer).toBeGreaterThan(0);
+			// buying it again is rejected
+			expect(room.buyTech("p0", "archer", "archerFireArrows")).toMatchObject({
+				ok: false,
+				code: "techAlreadyOwned",
+			});
+		}
+	});
+});
+
+describe("MatchRoom — hidden planning", () => {
+	test("a seat's own plan is not visible to the opponent until reveal", () => {
+		const room = newRoom();
+		startMatch(room);
+		expect(room.buySquad("p0", "footman", 0, 10, "north").ok).toBe(true);
+		// From seat 1's view, opponent (seat 0) shows only revealed cards (none yet
+		// this round beyond nothing revealed → empty until a plan-lock happens).
+		const oppView = room.snapshotFor(1).opponent!;
+		expect(oppView.cards.some((c) => c.unitId === "footman")).toBe(false);
+	});
+
+	test("both ready triggers plan-lock and captures the reveal", () => {
+		const room = newRoom();
+		startMatch(room);
+		expect(room.buySquad("p0", "footman", 0, 10, "north").ok).toBe(true);
+		expect(room.buySquad("p1", "archer", 0, 30, "north").ok).toBe(true);
+		expect(room.setReady("p0", true, 0).ok).toBe(true);
+		expect(room.currentPhase).toBe("planning");
+		expect(room.setReady("p1", true, 0).ok).toBe(true);
+		expect(room.currentPhase).toBe("battle");
+		// after battle the reveal exists
+		const armies = room.revealArmies();
+		expect(
+			armies
+				.find((a) => a.seat === 0)!
+				.cards.some((c) => c.unitId === "footman"),
+		).toBe(true);
+	});
+});
+
+describe("MatchRoom — battle stub & round result", () => {
+	function planLockWithArmies(room: MatchRoom): void {
+		startMatch(room);
+		// seat 0 buys more value than seat 1 → seat 0 should win the stub battle
+		expect(room.buySquad("p0", "footman", 0, 10, "north").ok).toBe(true);
+		expect(room.buySquad("p0", "archer", 20, 10, "north").ok).toBe(true);
+		expect(room.buySquad("p1", "footman", 0, 30, "north").ok).toBe(true);
+		room.setReady("p0", true, 0);
+		room.setReady("p1", true, 0);
+		expect(room.currentPhase).toBe("battle");
+	}
+
+	test("higher invested value wins and the loser takes HP damage", () => {
+		const room = newRoom();
+		planLockWithArmies(room);
+		// both ack → battle resolves
+		room.battleAck("p0", 0);
+		room.battleAck("p1", 0);
+		expect(room.currentPhase).toBe("results");
+		const result = room.lastRoundResult()!;
+		expect(result.winnerSeat).toBe(0);
+		const dmgToLoser = result.hpDamage.find((d) => d.seat === 1)!.amount;
+		expect(dmgToLoser).toBeGreaterThan(0);
+		expect(result.hpDamage.find((d) => d.seat === 0)!.amount).toBe(0);
+	});
+
+	test("results advances to the next planning round when both survive", () => {
+		const room = newRoom();
+		planLockWithArmies(room);
+		room.battleAck("p0", 0);
+		room.battleAck("p1", 0);
+		expect(room.currentPhase).toBe("results");
+		// advance past the results hold
+		room.tick(1_000_000);
+		expect(room.currentPhase).toBe("planning");
+		expect(room.currentRound).toBe(2);
+		// last round's plan is now the opponent's visible army
+		const oppView = room.snapshotFor(1).opponent!;
+		expect(oppView.cards.length).toBeGreaterThan(0);
+	});
+});
+
+describe("MatchRoom — a full match to HP zero", () => {
+	test("repeated rounds drive the loser's HP to zero and end the match", () => {
+		const room = newRoom();
+		startMatch(room);
+
+		// seat 0 grows its army each round (fresh coords, since cards persist), so
+		// its invested-value lead — and the per-round survivor damage — widens and
+		// seat 1 bleeds out. seat 1 idles. Rows chosen clear of the back-line
+		// buildings; ballista is unlocked once and spammed with the round's income.
+		let guard = 0;
+		let placed = 0;
+		while (room.currentPhase !== "matchEnded" && guard < 200) {
+			guard += 1;
+			if (room.currentPhase === "planning") {
+				room.unlockUnit("p0", "ballista");
+				// spend seat 0's whole allowance on new ballistae at fresh spots
+				for (let d = 0; d < 3; d++) {
+					const row = (placed % 10) * 3;
+					const col = 6 + Math.floor(placed / 10) * 5;
+					const r = room.buySquad("p0", "ballista", row, col, "north");
+					if (r.ok) placed += 1;
+				}
+				room.setReady("p0", true, 0);
+				room.setReady("p1", true, 0);
+			} else if (room.currentPhase === "battle") {
+				room.battleAck("p0", 0);
+				room.battleAck("p1", 0);
+			} else if (room.currentPhase === "results") {
+				room.tick(1_000_000);
+			}
+		}
+
+		expect(room.currentPhase).toBe("matchEnded");
+		expect(room.winner).toBe(0);
+		const finalHp = room.finalHp();
+		expect(finalHp.find((h) => h.seat === 1)!.hp).toBe(0);
+		expect(finalHp.find((h) => h.seat === 0)!.hp).toBeGreaterThan(0);
+	});
+
+	test("plays entirely via deadline ticks with no explicit acks", () => {
+		const room = newRoom();
+		room.join("p0", "Alice", 0);
+		room.join("p1", "Bob", 0);
+		// never pick a commander → commanderPick deadline auto-picks
+		let now = 0;
+		let guard = 0;
+		while (room.currentPhase !== "matchEnded" && guard < 500) {
+			guard += 1;
+			now += 200_000; // advance well past any deadline
+			if (room.currentPhase === "planning") {
+				// give seat 0 an edge each round
+				room.buySquad("p0", "footman", 0, 10, "north");
+			}
+			room.tick(now);
+		}
+		// With no purchases from seat 1 and seat 0 buying, seat 0 wins eventually.
+		expect(room.currentPhase).toBe("matchEnded");
+	});
+});
+
+describe("MatchRoom — reconnect", () => {
+	test("reconnecting with a resume token restores the seat and its state", () => {
+		const room = newRoom();
+		startMatch(room);
+		expect(room.buySquad("p0", "footman", 0, 10, "north").ok).toBe(true);
+		const token = `tok-m-0`; // deterministic token for seat 0
+		expect(room.seatByResumeToken(token)).toBe(0 as Seat);
+
+		room.disconnect("p0");
+		expect(room.snapshotFor(0).own.connected).toBe(false);
+
+		const rejoin = room.join("p0b", "Alice", 0, token);
+		expect(rejoin).not.toBeNull();
+		expect(rejoin!.seat).toBe(0 as Seat);
+		const own = room.snapshotFor(0).own;
+		expect(own.connected).toBe(true);
+		// state retained across reconnect
+		expect(own.cards.some((c) => c.unitId === "footman")).toBe(true);
+	});
+});

--- a/apps/game-server/src/matchRoom.ts
+++ b/apps/game-server/src/matchRoom.ts
@@ -1,0 +1,794 @@
+import type { ServerCatalog } from "./catalog";
+import { footprintTiles, footprintsOverlap } from "./catalog";
+import type {
+	CmdRejectCode,
+	MatchConfig,
+	MatchSnapshot,
+	OpponentView,
+	Orientation,
+	Phase,
+	Seat,
+	SeatView,
+	SquadCard,
+	UnitDef,
+} from "@core/types";
+
+/**
+ * MatchRoom — the pure reducer for one Mechabellum-style match (design doc §8).
+ *
+ * Phase machine: lobby → commanderPick → planning(1) → battle → results →
+ * planning(N+1) | matchEnded. Hidden simultaneous planning is just per-seat
+ * views. Battle resolution is a STUB in M3: no combat, damage = prorated
+ * invested value of the winner's survivors (invented per side by comparing
+ * total invested value). The real sim + battleLog arrive at M4/M5.
+ *
+ * Transport-free and clock-injected (`now` passed into every mutator, deadlines
+ * advanced via tick(now)) so it is fully deterministic and unit-testable — and
+ * a faithful spec for the C# port. It never uses Date.now() or Math.random().
+ */
+
+export type CommandOutcome =
+	| { ok: true }
+	| { ok: false; code: CmdRejectCode; message: string };
+
+type PendingBattle = {
+	/** Captured blueprint per seat at plan-lock (the reveal). */
+	armies: { seat: Seat; cards: SquadCard[] }[];
+	acked: Set<Seat>;
+};
+
+const SEATS: Seat[] = [0, 1];
+
+type SeatState = {
+	seat: Seat;
+	playerId: string | null;
+	playerName: string;
+	resumeToken: string;
+	connected: boolean;
+	commanderId: string | null;
+	commanderOffers: string[];
+	hp: number;
+	coin: number;
+	deploysRemaining: number;
+	unlocksRemaining: number;
+	ready: boolean;
+	cards: SquadCard[];
+	unlockedUnits: Set<string>;
+	purchasedTechs: Set<string>;
+	techPriceByUnit: Map<string, number>;
+	/** Snapshot of this seat's cards at the last plan-lock (opponent view). */
+	revealedCards: SquadCard[];
+};
+
+export class MatchRoom {
+	readonly id: string;
+	private readonly catalog: ServerCatalog;
+	private readonly rules: ServerCatalog["catalog"]["matchRules"];
+
+	private phase: Phase = "lobby";
+	private round = 0;
+	private phaseDeadline = 0;
+	private nextCardId = 1;
+	private pendingBattle: PendingBattle | null = null;
+	private matchWinner: Seat | null = null;
+
+	private readonly seats: SeatState[];
+
+	constructor(
+		id: string,
+		catalog: ServerCatalog,
+		tokenGen: (seat: Seat) => string,
+	) {
+		this.id = id;
+		this.catalog = catalog;
+		this.rules = catalog.catalog.matchRules;
+		this.seats = SEATS.map((seat) => ({
+			seat,
+			playerId: null,
+			playerName: "",
+			resumeToken: tokenGen(seat),
+			connected: false,
+			commanderId: null,
+			commanderOffers: [],
+			hp: 0,
+			coin: 0,
+			deploysRemaining: 0,
+			unlocksRemaining: 0,
+			ready: false,
+			cards: [],
+			unlockedUnits: new Set(),
+			purchasedTechs: new Set(),
+			techPriceByUnit: new Map(),
+			revealedCards: [],
+		}));
+	}
+
+	// -----------------------------------------------------------------------
+	// Membership / connection
+	// -----------------------------------------------------------------------
+
+	get currentPhase(): Phase {
+		return this.phase;
+	}
+	get currentRound(): number {
+		return this.round;
+	}
+	get isEmpty(): boolean {
+		return this.seats.every((s) => !s.connected);
+	}
+	get winner(): Seat | null {
+		return this.matchWinner;
+	}
+
+	/** True if both seats are occupied by a connected player. */
+	private get bothConnected(): boolean {
+		return this.seats.every((s) => s.connected);
+	}
+
+	seatByResumeToken(token: string): Seat | null {
+		const s = this.seats.find((s) => s.resumeToken === token);
+		return s ? s.seat : null;
+	}
+
+	/**
+	 * Seat a player. If `resumeToken` matches an existing seat, that seat
+	 * reconnects (keeps all state). Otherwise the first free seat is taken.
+	 * Returns the seat + its resumeToken, or null if the room is full.
+	 */
+	join(
+		playerId: string,
+		playerName: string,
+		now: number,
+		resumeToken?: string,
+	): { seat: Seat; resumeToken: string } | null {
+		if (resumeToken) {
+			const seatNo = this.seatByResumeToken(resumeToken);
+			if (seatNo !== null) {
+				const s = this.seats[seatNo];
+				s.playerId = playerId;
+				s.playerName = playerName || s.playerName;
+				s.connected = true;
+				return { seat: s.seat, resumeToken: s.resumeToken };
+			}
+		}
+		const free = this.seats.find((s) => !s.connected && s.playerId === null);
+		if (!free) return null;
+		free.playerId = playerId;
+		free.playerName = playerName;
+		free.connected = true;
+		this.maybeStartCommanderPick(now);
+		return { seat: free.seat, resumeToken: free.resumeToken };
+	}
+
+	/** Mark a seat disconnected (state is retained for reconnect). */
+	disconnect(playerId: string): void {
+		const s = this.seats.find((s) => s.playerId === playerId);
+		if (!s) return;
+		s.connected = false;
+	}
+
+	seatOfPlayer(playerId: string): Seat | null {
+		const s = this.seats.find((s) => s.playerId === playerId);
+		return s ? s.seat : null;
+	}
+
+	// -----------------------------------------------------------------------
+	// Phase transitions
+	// -----------------------------------------------------------------------
+
+	private maybeStartCommanderPick(now: number): void {
+		if (this.phase !== "lobby" || !this.bothConnected) return;
+		this.phase = "commanderPick";
+		const offered = this.rules.commandersOffered;
+		const all = this.rules.commanders.map((c) => c.id);
+		for (const s of this.seats) {
+			// Deterministic offers: rotate the commander list by seat so both
+			// seats see a stable, reproducible set (no RNG in the reducer).
+			s.commanderOffers = rotate(all, s.seat).slice(0, offered);
+			s.commanderId = null;
+		}
+		this.phaseDeadline = now + this.rules.timers.commanderPickSeconds * 1000;
+	}
+
+	/** Advance time-based deadlines. Returns true if a phase transition occurred. */
+	tick(now: number): boolean {
+		if (this.phaseDeadline !== 0 && now < this.phaseDeadline) return false;
+		switch (this.phase) {
+			case "commanderPick":
+				// Deadline hit: auto-pick the first offer for anyone undecided.
+				for (const s of this.seats) {
+					if (!s.commanderId) s.commanderId = s.commanderOffers[0] ?? null;
+				}
+				this.beginPlanning(1, now);
+				return true;
+			case "planning":
+				this.planLock(now);
+				return true;
+			case "battle":
+				this.resolveBattle(now);
+				return true;
+			case "results":
+				this.afterResults(now);
+				return true;
+			default:
+				return false;
+		}
+	}
+
+	private allCommandersPicked(): boolean {
+		return this.seats.every((s) => s.commanderId !== null);
+	}
+
+	private beginPlanning(round: number, now: number): void {
+		this.phase = "planning";
+		this.round = round;
+		for (const s of this.seats) {
+			// Materialize commander starting units + starting buildings on round 1.
+			if (round === 1) this.materializeStartingArmy(s);
+			// Income: 200 * round (+ commander economy mods), carried over.
+			const income = this.incomeForSeat(s, round);
+			s.coin += income;
+			s.deploysRemaining = this.deploysForSeat(s);
+			s.unlocksRemaining = this.unlocksForSeat(s);
+			s.ready = false;
+		}
+		this.phaseDeadline = now + this.rules.timers.deploySeconds * 1000;
+	}
+
+	private planLock(now: number): void {
+		// Capture the reveal snapshot once — used as the battle reveal and as
+		// next round's opponent view.
+		for (const s of this.seats) s.revealedCards = s.cards.map(cloneCard);
+		this.pendingBattle = {
+			armies: this.seats.map((s) => ({
+				seat: s.seat,
+				cards: s.revealedCards.map(cloneCard),
+			})),
+			acked: new Set(),
+		};
+		this.phase = "battle";
+		this.phaseDeadline = now + this.rules.timers.battleSeconds * 1000;
+	}
+
+	/** Record a battle ack; both acked (or deadline via tick) ends the battle. */
+	battleAck(playerId: string, now: number): void {
+		if (this.phase !== "battle" || !this.pendingBattle) return;
+		const seat = this.seatOfPlayer(playerId);
+		if (seat === null) return;
+		this.pendingBattle.acked.add(seat);
+		if (this.pendingBattle.acked.size === SEATS.length) this.resolveBattle(now);
+	}
+
+	private lastResult: {
+		round: number;
+		winnerSeat: Seat | null;
+		hpDamage: { seat: Seat; amount: number }[];
+	} | null = null;
+
+	private resolveBattle(now: number): void {
+		if (this.phase !== "battle") return;
+		const armies = this.pendingBattle?.armies ?? [];
+
+		// STUB resolver: total invested value decides the winner; the loser takes
+		// HP damage equal to the winner's prorated survivor value. With no combat,
+		// "survivors" = all of the winner's card-backed units at full strength, so
+		// survivor value == the winner's invested value scaled by a margin factor.
+		const investedBySeat = new Map<Seat, number>();
+		for (const army of armies) {
+			const total = army.cards.reduce((sum, c) => sum + c.invested, 0);
+			investedBySeat.set(army.seat, total);
+		}
+		const a = investedBySeat.get(0) ?? 0;
+		const b = investedBySeat.get(1) ?? 0;
+
+		let winnerSeat: Seat | null;
+		let damage: number;
+		if (a === b) {
+			// Draw (incl. both empty) → both take the timeout survivor value.
+			winnerSeat = null;
+			damage = Math.round(Math.min(a, b) * SURVIVOR_FACTOR);
+		} else {
+			winnerSeat = a > b ? 0 : 1;
+			const winnerValue = Math.max(a, b);
+			const loserValue = Math.min(a, b);
+			// Prorated survivor value: the margin the winner kept, floored so a win
+			// always stings even against a near-equal army.
+			damage = Math.max(
+				MIN_ROUND_DAMAGE,
+				Math.round((winnerValue - loserValue) * SURVIVOR_FACTOR),
+			);
+		}
+
+		const hpDamage: { seat: Seat; amount: number }[] = [];
+		for (const s of this.seats) {
+			const takesDamage = winnerSeat === null || s.seat !== winnerSeat;
+			const amount = takesDamage ? damage : 0;
+			if (amount > 0) s.hp = Math.max(0, s.hp - amount);
+			hpDamage.push({ seat: s.seat, amount });
+		}
+
+		this.lastResult = { round: this.round, winnerSeat, hpDamage };
+		this.pendingBattle = null;
+		this.phase = "results";
+		this.phaseDeadline = now + this.rules.timers.resultsHoldSeconds * 1000;
+	}
+
+	private afterResults(now: number): void {
+		if (this.phase !== "results") return;
+		const dead = this.seats.filter((s) => s.hp <= 0);
+		if (dead.length > 0) {
+			// Match over. Winner = the seat with more HP (or null if both dead).
+			const alive = this.seats.filter((s) => s.hp > 0);
+			this.matchWinner = alive.length === 1 ? alive[0].seat : null;
+			this.phase = "matchEnded";
+			this.phaseDeadline = 0;
+			return;
+		}
+		this.beginPlanning(this.round + 1, now);
+	}
+
+	// -----------------------------------------------------------------------
+	// Economy helpers
+	// -----------------------------------------------------------------------
+
+	private incomeForSeat(s: SeatState, round: number): number {
+		let income = this.rules.income.perRoundIncrement * round;
+		if (round === 1) income += this.rules.income.startingIncome;
+		income += this.commanderEconomy(s).incomePerRoundAdd;
+		return income;
+	}
+
+	private deploysForSeat(s: SeatState): number {
+		return this.rules.deploysPerRound + this.commanderEconomy(s).deploySlotsAdd;
+	}
+
+	private unlocksForSeat(s: SeatState): number {
+		return this.rules.unlocksPerRound + this.commanderEconomy(s).unlockSlotsAdd;
+	}
+
+	private commanderEconomy(s: SeatState): {
+		incomePerRoundAdd: number;
+		deploySlotsAdd: number;
+		unlockSlotsAdd: number;
+		startingIncomeAdd: number;
+	} {
+		const acc = {
+			incomePerRoundAdd: 0,
+			deploySlotsAdd: 0,
+			unlockSlotsAdd: 0,
+			startingIncomeAdd: 0,
+		};
+		if (!s.commanderId) return acc;
+		const cmd = this.rules.commanders.find((c) => c.id === s.commanderId);
+		if (!cmd) return acc;
+		for (const ability of cmd.ability) {
+			if (ability.kind === "economyMod") {
+				acc.incomePerRoundAdd += ability.incomePerRoundAdd;
+				acc.deploySlotsAdd += ability.deploySlotsAdd;
+				acc.unlockSlotsAdd += ability.unlockSlotsAdd;
+				acc.startingIncomeAdd += ability.startingIncomeAdd;
+			}
+		}
+		return acc;
+	}
+
+	private materializeStartingArmy(s: SeatState): void {
+		// Commander HP is the player HP pool.
+		const cmd = this.rules.commanders.find((c) => c.id === s.commanderId);
+		s.hp = cmd?.hp ?? 5000;
+		s.coin = this.commanderEconomy(s).startingIncomeAdd;
+		// Starting buildings for this seat.
+		for (const b of this.rules.startingBuildings) {
+			if (b.seat !== s.seat) continue;
+			this.addCard(s, b.unitId, b.anchor.row, b.anchor.col, b.orientation, 0, {
+				free: true,
+			});
+		}
+		// Commander starting units.
+		for (const su of cmd?.startingUnits ?? []) {
+			this.addCard(
+				s,
+				su.unitId,
+				su.anchor.row,
+				su.anchor.col,
+				su.orientation,
+				0,
+				{
+					free: true,
+				},
+			);
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Planning commands
+	// -----------------------------------------------------------------------
+
+	pickCommander(
+		playerId: string,
+		commanderId: string,
+		now: number,
+	): CommandOutcome {
+		const s = this.requireSeat(playerId);
+		if (!s) return fail("notJoined", "not in this room");
+		if (this.phase !== "commanderPick")
+			return fail("wrongPhase", "not in commander pick");
+		if (!s.commanderOffers.includes(commanderId))
+			return fail("unknownCommander", `commander ${commanderId} not offered`);
+		if (s.commanderId) return fail("commanderAlreadyPicked", "already picked");
+		s.commanderId = commanderId;
+		if (this.allCommandersPicked()) this.beginPlanning(1, now);
+		return { ok: true };
+	}
+
+	buySquad(
+		playerId: string,
+		unitId: string,
+		row: number,
+		col: number,
+		orientation: Orientation,
+	): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const unit = this.catalog.unitById.get(unitId);
+		if (!unit) return fail("unknownUnit", `no unit ${unitId}`);
+		if (unit.cost.unlockCost > 0 && !s.unlockedUnits.has(unitId))
+			return fail("notUnlocked", `${unitId} is not unlocked`);
+		if (s.deploysRemaining <= 0)
+			return fail("noDeploysLeft", "no deploys left");
+		if (s.coin < unit.cost.deployCost)
+			return fail("insufficientFunds", "not enough coin");
+		const placement = this.validatePlacement(
+			s,
+			unit,
+			row,
+			col,
+			orientation,
+			null,
+		);
+		if (placement) return placement;
+
+		s.coin -= unit.cost.deployCost;
+		s.deploysRemaining -= 1;
+		this.addCard(s, unitId, row, col, orientation, unit.cost.deployCost, {
+			free: false,
+		});
+		return { ok: true };
+	}
+
+	moveSquad(
+		playerId: string,
+		cardId: string,
+		row: number,
+		col: number,
+		orientation: Orientation,
+	): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const card = s.cards.find((c) => c.cardId === cardId);
+		if (!card) return fail("unknownCard", `no card ${cardId}`);
+		const unit = this.catalog.unitById.get(card.unitId);
+		if (!unit) return fail("unknownUnit", `card unit ${card.unitId} missing`);
+		const placement = this.validatePlacement(
+			s,
+			unit,
+			row,
+			col,
+			orientation,
+			cardId,
+		);
+		if (placement) return placement;
+		card.anchor = { row, col };
+		card.orientation = orientation;
+		return { ok: true };
+	}
+
+	sellSquad(playerId: string, cardId: string): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const idx = s.cards.findIndex((c) => c.cardId === cardId);
+		if (idx < 0) return fail("unknownCard", `no card ${cardId}`);
+		const card = s.cards[idx];
+		// Only this-round purchases can be sold (free revert).
+		if (card.purchasedRound !== this.round)
+			return fail(
+				"notThisRoundPurchase",
+				"can only sell this round's purchases",
+			);
+		s.cards.splice(idx, 1);
+		s.coin += card.invested;
+		s.deploysRemaining += 1;
+		return { ok: true };
+	}
+
+	unlockUnit(playerId: string, unitId: string): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const unit = this.catalog.unitById.get(unitId);
+		if (!unit) return fail("unknownUnit", `no unit ${unitId}`);
+		if (s.unlockedUnits.has(unitId))
+			return fail("alreadyUnlocked", "already unlocked");
+		if (s.unlocksRemaining <= 0)
+			return fail("noUnlocksLeft", "no unlocks left");
+		if (s.coin < unit.cost.unlockCost)
+			return fail("insufficientFunds", "not enough coin");
+		s.coin -= unit.cost.unlockCost;
+		s.unlocksRemaining -= 1;
+		s.unlockedUnits.add(unitId);
+		return { ok: true };
+	}
+
+	buyTech(playerId: string, unitId: string, techId: string): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const unit = this.catalog.unitById.get(unitId);
+		if (!unit) return fail("unknownUnit", `no unit ${unitId}`);
+		const tech = unit.techs.find((t) => t.id === techId);
+		if (!tech) return fail("unknownTech", `no tech ${techId} on ${unitId}`);
+		if (s.purchasedTechs.has(techId))
+			return fail("techAlreadyOwned", "already owned");
+		const price = s.techPriceByUnit.get(unitId) ?? tech.cost;
+		if (s.coin < price) return fail("insufficientFunds", "not enough coin");
+		s.coin -= price;
+		s.purchasedTechs.add(techId);
+		// Escalate this unit type's other tech prices.
+		s.techPriceByUnit.set(
+			unitId,
+			(s.techPriceByUnit.get(unitId) ?? tech.cost) +
+				this.rules.techPriceEscalation,
+		);
+		return { ok: true };
+	}
+
+	buyLevel(playerId: string, cardId: string): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		const card = s.cards.find((c) => c.cardId === cardId);
+		if (!card) return fail("unknownCard", `no card ${cardId}`);
+		const unit = this.catalog.unitById.get(card.unitId);
+		if (!unit) return fail("unknownUnit", `card unit ${card.unitId} missing`);
+		if (card.xp < unit.squad.xpToLevel)
+			return fail("xpNotReady", "not enough xp to level");
+		const cost = Math.round(
+			unit.cost.deployCost * this.rules.leveling.upgradeCostFraction,
+		);
+		if (s.coin < cost) return fail("insufficientFunds", "not enough coin");
+		s.coin -= cost;
+		card.xp -= unit.squad.xpToLevel;
+		card.level += 1;
+		card.invested += cost;
+		return { ok: true };
+	}
+
+	setReady(playerId: string, ready: boolean, now: number): CommandOutcome {
+		const s = this.requirePlanningSeat(playerId);
+		if ("code" in s) return s;
+		s.ready = ready;
+		if (this.seats.every((s) => s.ready)) this.planLock(now);
+		return { ok: true };
+	}
+
+	// -----------------------------------------------------------------------
+	// Snapshots
+	// -----------------------------------------------------------------------
+
+	matchConfig(): MatchConfig {
+		return {
+			board: { w: this.rules.board.w, h: this.rules.board.h },
+			deploysPerRound: this.rules.deploysPerRound,
+			unlocksPerRound: this.rules.unlocksPerRound,
+			incomePerRoundIncrement: this.rules.income.perRoundIncrement,
+			deploySeconds: this.rules.timers.deploySeconds,
+			battleSeconds: this.rules.timers.battleSeconds,
+			commanderPickSeconds: this.rules.timers.commanderPickSeconds,
+			commandersOffered: this.rules.commandersOffered,
+		};
+	}
+
+	snapshotFor(seat: Seat): MatchSnapshot {
+		const own = this.seats[seat];
+		const opp = this.seats[seat === 0 ? 1 : 0];
+		return {
+			phase: this.phase,
+			round: this.round,
+			phaseDeadline: this.phaseDeadline,
+			commanderOffers: own.commanderOffers,
+			own: this.seatView(own),
+			opponent: opp.connected || opp.playerId ? this.opponentView(opp) : null,
+		};
+	}
+
+	lastRoundResult(): {
+		round: number;
+		winnerSeat: Seat | null;
+		hpDamage: { seat: Seat; amount: number }[];
+		hp: { seat: Seat; hp: number }[];
+	} | null {
+		if (!this.lastResult) return null;
+		return {
+			...this.lastResult,
+			hp: this.seats.map((s) => ({ seat: s.seat, hp: s.hp })),
+		};
+	}
+
+	revealArmies(): { seat: Seat; cards: SquadCard[] }[] {
+		return this.seats.map((s) => ({
+			seat: s.seat,
+			cards: s.revealedCards.map(cloneCard),
+		}));
+	}
+
+	finalHp(): { seat: Seat; hp: number }[] {
+		return this.seats.map((s) => ({ seat: s.seat, hp: s.hp }));
+	}
+
+	private seatView(s: SeatState): SeatView {
+		return {
+			seat: s.seat,
+			playerName: s.playerName,
+			connected: s.connected,
+			commanderId: s.commanderId,
+			hp: s.hp,
+			coin: s.coin,
+			deploysRemaining: s.deploysRemaining,
+			unlocksRemaining: s.unlocksRemaining,
+			ready: s.ready,
+			cards: s.cards.map(cloneCard),
+			tech: {
+				unlockedUnits: [...s.unlockedUnits],
+				purchasedTechs: [...s.purchasedTechs],
+				techPriceByUnit: Object.fromEntries(s.techPriceByUnit),
+			},
+		};
+	}
+
+	private opponentView(s: SeatState): OpponentView {
+		return {
+			seat: s.seat,
+			playerName: s.playerName,
+			connected: s.connected,
+			commanderId: s.commanderId,
+			hp: s.hp,
+			// Only the LAST revealed army is visible — never this round's hidden plan.
+			cards: s.revealedCards.map(cloneCard),
+		};
+	}
+
+	// -----------------------------------------------------------------------
+	// Internals
+	// -----------------------------------------------------------------------
+
+	private requireSeat(playerId: string): SeatState | null {
+		return this.seats.find((s) => s.playerId === playerId) ?? null;
+	}
+
+	private requirePlanningSeat(
+		playerId: string,
+	): SeatState | { ok: false; code: CmdRejectCode; message: string } {
+		const s = this.requireSeat(playerId);
+		if (!s) return fail("notJoined", "not in this room");
+		if (this.phase !== "planning") return fail("wrongPhase", "not in planning");
+		return s;
+	}
+
+	private addCard(
+		s: SeatState,
+		unitId: string,
+		row: number,
+		col: number,
+		orientation: Orientation,
+		invested: number,
+		opts: { free: boolean },
+	): SquadCard {
+		const card: SquadCard = {
+			cardId: `sq${this.nextCardId++}`,
+			unitId,
+			anchor: { row, col },
+			orientation,
+			level: 1,
+			xp: 0,
+			purchasedRound: opts.free ? 0 : this.round,
+			invested,
+		};
+		s.cards.push(card);
+		return card;
+	}
+
+	/**
+	 * Placement validation reusing the shared footprint helpers: board bounds,
+	 * own-half (deploy zone, buildings exempt), and no overlap with the seat's
+	 * other cards (ignoreCardId lets a move overlap its own current tiles).
+	 */
+	private validatePlacement(
+		s: SeatState,
+		unit: UnitDef,
+		row: number,
+		col: number,
+		_orientation: Orientation,
+		ignoreCardId: string | null,
+	): { ok: false; code: CmdRejectCode; message: string } | null {
+		if (!Number.isInteger(row) || !Number.isInteger(col))
+			return fail("outOfBounds", "non-integer tile");
+		const tiles = footprintTiles(unit, row, col);
+		const board = this.rules.board;
+		if (
+			tiles.rowStart < 0 ||
+			tiles.colStart < 0 ||
+			tiles.rowEnd > board.w - 1 ||
+			tiles.colEnd > board.h - 1
+		)
+			return fail(
+				"outOfBounds",
+				`does not fit the ${board.w}x${board.h} board`,
+			);
+
+		if (
+			unit.placement.domain !== "building" &&
+			!this.withinSeatZones(s.seat, tiles)
+		)
+			return fail("outsideOwnHalf", "outside your deploy zone");
+
+		for (const other of s.cards) {
+			if (other.cardId === ignoreCardId) continue;
+			const otherUnit = this.catalog.unitById.get(other.unitId);
+			if (!otherUnit) continue;
+			const otherTiles = footprintTiles(
+				otherUnit,
+				other.anchor.row,
+				other.anchor.col,
+			);
+			if (footprintsOverlap(tiles, otherTiles))
+				return fail("tileOccupied", `overlaps card ${other.cardId}`);
+		}
+		return null;
+	}
+
+	private withinSeatZones(
+		seat: Seat,
+		tiles: {
+			rowStart: number;
+			rowEnd: number;
+			colStart: number;
+			colEnd: number;
+		},
+	): boolean {
+		for (const zone of this.rules.deployZones) {
+			if (zone.seat !== seat) continue;
+			const r = zone.rect;
+			if (
+				tiles.rowStart >= r.row &&
+				tiles.rowEnd <= r.row + r.w - 1 &&
+				tiles.colStart >= r.col &&
+				tiles.colEnd <= r.col + r.h - 1
+			) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+// Stub-resolver tuning: fraction of value converted to HP damage, and a floor.
+const SURVIVOR_FACTOR = 0.5;
+const MIN_ROUND_DAMAGE = 100;
+
+function cloneCard(c: SquadCard): SquadCard {
+	return { ...c, anchor: { ...c.anchor } };
+}
+
+function rotate<T>(arr: T[], by: number): T[] {
+	if (arr.length === 0) return arr;
+	const n = ((by % arr.length) + arr.length) % arr.length;
+	return [...arr.slice(n), ...arr.slice(0, n)];
+}
+
+function fail(
+	code: CmdRejectCode,
+	message: string,
+): {
+	ok: false;
+	code: CmdRejectCode;
+	message: string;
+} {
+	return { ok: false, code, message };
+}

--- a/apps/game-server/src/matchServer.test.ts
+++ b/apps/game-server/src/matchServer.test.ts
@@ -1,0 +1,261 @@
+import {
+	PROTOCOL_VERSION,
+	type ClientMessageV2,
+	type ServerMessageV2,
+	parseServerMessageV2,
+} from "@core/types";
+import { afterEach, describe, expect, test } from "bun:test";
+import { type MatchServer, createMatchServer } from "./matchServer";
+
+const servers: MatchServer[] = [];
+
+function startServer(): MatchServer {
+	// tickMs 0 disables the deadline ticker so tests drive phases explicitly.
+	const gs = createMatchServer({ port: 0, tickMs: 0, now: () => 1000 });
+	servers.push(gs);
+	return gs;
+}
+
+afterEach(() => {
+	for (const gs of servers.splice(0)) gs.stop();
+});
+
+class Client {
+	private readonly ws: WebSocket;
+	private readonly queue: ServerMessageV2[] = [];
+	private readonly waiters: Array<(m: ServerMessageV2) => void> = [];
+
+	private constructor(ws: WebSocket) {
+		this.ws = ws;
+		ws.onmessage = (e) => {
+			const parsed = parseServerMessageV2(String(e.data));
+			if (!parsed.ok) throw new Error(`unparseable: ${parsed.error}`);
+			const w = this.waiters.shift();
+			if (w) w(parsed.message);
+			else this.queue.push(parsed.message);
+		};
+	}
+
+	static async connect(gs: MatchServer): Promise<Client> {
+		const ws = new WebSocket(`ws://localhost:${gs.server.port}/ws`);
+		await new Promise<void>((resolve, reject) => {
+			ws.onopen = () => resolve();
+			ws.onerror = () => reject(new Error("connect failed"));
+		});
+		return new Client(ws);
+	}
+
+	send(m: ClientMessageV2): void {
+		this.ws.send(JSON.stringify(m));
+	}
+
+	next(timeoutMs = 2000): Promise<ServerMessageV2> {
+		const q = this.queue.shift();
+		if (q) return Promise.resolve(q);
+		return new Promise((resolve, reject) => {
+			const t = setTimeout(() => reject(new Error("timeout")), timeoutMs);
+			this.waiters.push((m) => {
+				clearTimeout(t);
+				resolve(m);
+			});
+		});
+	}
+
+	/** Drain until a message of the given type arrives (skips others). */
+	async until(
+		type: ServerMessageV2["type"],
+		timeoutMs = 2000,
+	): Promise<ServerMessageV2> {
+		const deadline = Date.now() + timeoutMs;
+		while (Date.now() < deadline) {
+			const m = await this.next(timeoutMs);
+			if (m.type === type) return m;
+		}
+		throw new Error(`never saw ${type}`);
+	}
+
+	close(): void {
+		this.ws.close();
+	}
+}
+
+async function join(
+	gs: MatchServer,
+	room: string,
+	name: string,
+): Promise<{ client: Client; welcome: ServerMessageV2 }> {
+	const client = await Client.connect(gs);
+	client.send({
+		type: "join",
+		roomId: room,
+		playerName: name,
+		protocolVersion: PROTOCOL_VERSION,
+	});
+	const welcome = await client.next();
+	return { client, welcome };
+}
+
+describe("match server — protocol v2 transport", () => {
+	test("GET /health advertises protocol v2 and the catalog hash", async () => {
+		const gs = startServer();
+		const health = (await fetch(
+			`http://localhost:${gs.server.port}/health`,
+		).then((r) => r.json())) as {
+			status: string;
+			protocolVersion: number;
+			catalogHash: string;
+		};
+		expect(health.status).toBe("ok");
+		expect(health.protocolVersion).toBe(PROTOCOL_VERSION);
+		expect(health.catalogHash).toBe(gs.catalog.hash);
+	});
+
+	test("join returns a welcome with seat, catalog bytes, and match config", async () => {
+		const gs = startServer();
+		const { welcome } = await join(gs, "r", "Alice");
+		expect(welcome.type).toBe("welcome");
+		if (welcome.type === "welcome") {
+			expect(welcome.seat).toBe(0);
+			expect(welcome.catalogHash).toBe(gs.catalog.hash);
+			// welcome carries the EXACT catalog bytes
+			expect(welcome.catalogJson.length).toBeGreaterThan(100);
+			expect(welcome.matchConfig.board).toEqual({ w: 32, h: 48 });
+		}
+	});
+
+	test("two joins reach commanderPick and a pick is accepted", async () => {
+		const gs = startServer();
+		const { client: a } = await join(gs, "r", "Alice");
+		const { client: b } = await join(gs, "r", "Bob");
+
+		// both should receive a phase update landing in commanderPick
+		const aPhase = await a.until("phase");
+		expect(aPhase.type === "phase" && aPhase.match.phase).toBe("commanderPick");
+
+		// Alice picks her first offer
+		const offers = aPhase.type === "phase" ? aPhase.match.commanderOffers : [];
+		a.send({ type: "pickCommander", cmdId: "c1", commanderId: offers[0] });
+		const accepted = await a.until("cmdAccepted");
+		expect(accepted.type).toBe("cmdAccepted");
+
+		void b;
+	});
+
+	test("a full round: pick, buy, ready, reveal, battleStarted, roundResult", async () => {
+		const gs = startServer();
+		const { client: a } = await join(gs, "r", "Alice");
+		const { client: b } = await join(gs, "r", "Bob");
+
+		const aPhase = await a.until("phase");
+		const bPhase = await b.until("phase");
+		const aOffers = aPhase.type === "phase" ? aPhase.match.commanderOffers : [];
+		const bOffers = bPhase.type === "phase" ? bPhase.match.commanderOffers : [];
+
+		a.send({ type: "pickCommander", cmdId: "a1", commanderId: aOffers[0] });
+		b.send({ type: "pickCommander", cmdId: "b1", commanderId: bOffers[0] });
+
+		// both land in planning
+		const aPlan = await a.until("phase");
+		expect(aPlan.type === "phase" && aPlan.match.phase).toBe("planning");
+
+		// Alice out-invests: buy an archer in her half
+		a.send({
+			type: "buySquad",
+			cmdId: "a2",
+			unitId: "archer",
+			anchor: { row: 0, col: 10 },
+			orientation: "north",
+		});
+		b.send({
+			type: "buySquad",
+			cmdId: "b2",
+			unitId: "footman",
+			anchor: { row: 0, col: 30 },
+			orientation: "north",
+		});
+		await a.until("cmdAccepted");
+		await b.until("cmdAccepted");
+
+		// both ready → plan-lock → battle
+		a.send({ type: "setReady", cmdId: "a3", ready: true });
+		b.send({ type: "setReady", cmdId: "b3", ready: true });
+
+		// Alice should see a reveal + battleStarted
+		const reveal = await a.until("revealSnapshot");
+		expect(reveal.type).toBe("revealSnapshot");
+		const started = await a.until("battleStarted");
+		expect(started.type === "battleStarted" && started.hasBattleLog).toBe(
+			false,
+		);
+
+		// ack the battle → roundResult
+		a.send({ type: "battleAck" });
+		b.send({ type: "battleAck" });
+		const result = await a.until("roundResult");
+		expect(result.type).toBe("roundResult");
+		if (result.type === "roundResult") {
+			// Alice (seat 0) invested more (archer 100 vs footman 100 — but she also
+			// has commander/starting differences); at minimum a winner or a draw is
+			// reported and HP is present.
+			expect(result.hp.length).toBe(2);
+		}
+	});
+
+	test("hidden planning: opponent view never leaks the current plan", async () => {
+		const gs = startServer();
+		const { client: a } = await join(gs, "r", "Alice");
+		const { client: b } = await join(gs, "r", "Bob");
+		const aPhase = await a.until("phase");
+		const bPhase = await b.until("phase");
+		a.send({
+			type: "pickCommander",
+			cmdId: "a1",
+			commanderId:
+				aPhase.type === "phase" ? aPhase.match.commanderOffers[0] : "",
+		});
+		b.send({
+			type: "pickCommander",
+			cmdId: "b1",
+			commanderId:
+				bPhase.type === "phase" ? bPhase.match.commanderOffers[0] : "",
+		});
+		await a.until("phase"); // planning
+
+		a.send({
+			type: "buySquad",
+			cmdId: "a2",
+			unitId: "archer",
+			anchor: { row: 0, col: 10 },
+			orientation: "north",
+		});
+		await a.until("cmdAccepted");
+
+		// Bob asks for nothing; his view of Alice must not contain the archer.
+		b.send({ type: "ping" });
+		// Trigger a fresh phase snapshot for Bob by having Bob act.
+		b.send({
+			type: "buySquad",
+			cmdId: "b2",
+			unitId: "footman",
+			anchor: { row: 0, col: 30 },
+			orientation: "north",
+		});
+		const bAccept = await b.until("cmdAccepted");
+		if (bAccept.type === "cmdAccepted") {
+			const opp = bAccept.match.opponent;
+			expect(opp?.cards.some((c) => c.unitId === "archer")).toBe(false);
+		}
+	});
+
+	test("a rejected command returns cmdRejected to the sender", async () => {
+		const gs = startServer();
+		const { client: a } = await join(gs, "r", "Alice");
+		await join(gs, "r", "Bob");
+		const aPhase = await a.until("phase");
+		// pickCommander with an unoffered id
+		a.send({ type: "pickCommander", cmdId: "x", commanderId: "notReal" });
+		const rej = await a.until("cmdRejected");
+		expect(rej.type === "cmdRejected" && rej.code).toBe("unknownCommander");
+		void aPhase;
+	});
+});

--- a/apps/game-server/src/matchServer.ts
+++ b/apps/game-server/src/matchServer.ts
@@ -1,0 +1,389 @@
+import { loadEmbeddedCatalog } from "@core/catalog/embedded";
+import {
+	PROTOCOL_VERSION,
+	type Seat,
+	type ServerMessageV2,
+	parseClientMessageV2,
+} from "@core/types";
+import type { Server, ServerWebSocket } from "bun";
+import { type ServerCatalog, indexCatalog } from "./catalog";
+import { type CommandOutcome, MatchRoom } from "./matchRoom";
+
+/**
+ * Match server — protocol V2 over WebSocket, driving the MatchRoom reducer
+ * (design doc §8). The interim Bun implementation (C1); the C# BattleServer
+ * (M5) ports the same reducer + protocol. Battle resolution is the stub until
+ * the sim lands (M4/M5), so `battleStarted.hasBattleLog` is false and no
+ * `battleLog` is emitted.
+ *
+ * Deadlines: a single interval drives every room's `tick(now)`, so the phase
+ * machine advances even when a client never sends `setReady`/`battleAck`.
+ */
+
+export type MatchSocketData = {
+	playerId: string;
+	roomId: string | null;
+	seat: Seat | null;
+};
+
+type MatchSocket = ServerWebSocket<MatchSocketData>;
+
+export type MatchServer = {
+	server: Server<MatchSocketData>;
+	rooms: ReadonlyMap<string, MatchRoom>;
+	catalog: ServerCatalog;
+	stop: () => void;
+};
+
+export const DEFAULT_MATCH_PORT = 7778;
+
+export function matchPortFromEnv(): number {
+	const raw = process.env.MATCH_PORT;
+	if (raw === undefined || raw === "") return DEFAULT_MATCH_PORT;
+	const parsed = Number(raw);
+	if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+		throw new Error(
+			`invalid MATCH_PORT ${JSON.stringify(raw)} — expected an integer between 1 and 65535`,
+		);
+	}
+	return parsed;
+}
+
+export function createMatchServer(
+	options: {
+		port?: number;
+		catalog?: ServerCatalog;
+		catalogJson?: string;
+		/** Injected clock for deterministic tests (defaults to Date.now). */
+		now?: () => number;
+		/** Interval ms for the deadline ticker (0 disables it, for tests). */
+		tickMs?: number;
+	} = {},
+): MatchServer {
+	const { catalog, canonicalJson } = (() => {
+		if (options.catalog && options.catalogJson) {
+			return { catalog: options.catalog, canonicalJson: options.catalogJson };
+		}
+		const embedded = loadEmbeddedCatalog();
+		return {
+			catalog: options.catalog ?? indexCatalog(embedded.catalog, embedded.hash),
+			canonicalJson: options.catalogJson ?? embedded.canonicalJson,
+		};
+	})();
+
+	const now = options.now ?? (() => Date.now());
+	const rooms = new Map<string, MatchRoom>();
+	// playerId → socket, so a seat's private view goes only to its own client.
+	const socketsByPlayer = new Map<string, MatchSocket>();
+	let tokenCounter = 0;
+
+	const topic = (roomId: string) => `match:${roomId}`;
+
+	const send = (ws: MatchSocket, message: ServerMessageV2) =>
+		ws.send(JSON.stringify(message));
+
+	const sendToSeat = (roomId: string, seat: Seat, message: ServerMessageV2) => {
+		const room = rooms.get(roomId);
+		if (!room) return;
+		// find the player occupying that seat
+		for (const [playerId, sock] of socketsByPlayer) {
+			if (sock.data.roomId === roomId && sock.data.seat === seat) {
+				send(sock, message);
+			}
+			void playerId;
+		}
+	};
+
+	/** Send each seat its own private phase snapshot. */
+	const broadcastPhase = (roomId: string) => {
+		const room = rooms.get(roomId);
+		if (!room) return;
+		for (const seat of [0, 1] as Seat[]) {
+			sendToSeat(roomId, seat, {
+				type: "phase",
+				match: room.snapshotFor(seat),
+			});
+		}
+	};
+
+	// Track phase per room to detect transitions the ticker causes.
+	const lastPhase = new Map<string, string>();
+
+	const reactToTransitions = (roomId: string) => {
+		const room = rooms.get(roomId);
+		if (!room) return;
+		const phase = room.currentPhase;
+		const prev = lastPhase.get(roomId);
+		if (phase === prev) return;
+		lastPhase.set(roomId, phase);
+
+		if (phase === "battle") {
+			// Reveal + battleStarted (stub: no battleLog).
+			const reveal: ServerMessageV2 = {
+				type: "revealSnapshot",
+				round: room.currentRound,
+				armies: room.revealArmies(),
+			};
+			server.publish(topic(roomId), JSON.stringify(reveal));
+			const started: ServerMessageV2 = {
+				type: "battleStarted",
+				round: room.currentRound,
+				startAtServerMs: now(),
+				hasBattleLog: false,
+			};
+			server.publish(topic(roomId), JSON.stringify(started));
+		} else if (phase === "results") {
+			const result = room.lastRoundResult();
+			if (result) {
+				const msg: ServerMessageV2 = {
+					type: "roundResult",
+					round: result.round,
+					winnerSeat: result.winnerSeat,
+					hpDamage: result.hpDamage,
+					hp: result.hp,
+					summary: describeResult(result.winnerSeat),
+				};
+				server.publish(topic(roomId), JSON.stringify(msg));
+			}
+		} else if (phase === "matchEnded") {
+			const msg: ServerMessageV2 = {
+				type: "matchEnded",
+				winnerSeat: room.winner,
+				finalHp: room.finalHp(),
+			};
+			server.publish(topic(roomId), JSON.stringify(msg));
+		}
+		broadcastPhase(roomId);
+	};
+
+	const server = Bun.serve<MatchSocketData>({
+		port: options.port ?? matchPortFromEnv(),
+		fetch(req, server) {
+			const url = new URL(req.url);
+			if (url.pathname === "/health") {
+				let players = 0;
+				for (const s of socketsByPlayer.values())
+					if (s.data.roomId) players += 1;
+				return Response.json({
+					status: "ok",
+					protocolVersion: PROTOCOL_VERSION,
+					rooms: rooms.size,
+					players,
+					catalogHash: catalog.hash,
+					board: catalog.board,
+				});
+			}
+			if (url.pathname === "/ws") {
+				const upgraded = server.upgrade(req, {
+					data: { playerId: crypto.randomUUID(), roomId: null, seat: null },
+				});
+				if (upgraded) return undefined;
+				return new Response("expected a WebSocket upgrade", { status: 400 });
+			}
+			return new Response("boardgame match-server — connect via /ws", {
+				status: url.pathname === "/" ? 200 : 404,
+			});
+		},
+		websocket: {
+			message(ws: MatchSocket, raw) {
+				if (typeof raw !== "string") {
+					send(ws, {
+						type: "error",
+						code: "badMessage",
+						message: "expected text frame",
+					});
+					return;
+				}
+				const parsed = parseClientMessageV2(raw);
+				if (!parsed.ok) {
+					send(ws, {
+						type: "error",
+						code: "badMessage",
+						message: parsed.error,
+					});
+					return;
+				}
+				const msg = parsed.message;
+
+				if (msg.type === "ping") {
+					send(ws, { type: "pong" });
+					return;
+				}
+
+				if (msg.type === "join") {
+					handleJoin(ws, msg.roomId, msg.playerName, msg.resumeToken);
+					return;
+				}
+
+				const roomId = ws.data.roomId;
+				const room = roomId !== null ? rooms.get(roomId) : undefined;
+				if (roomId === null || !room) {
+					send(ws, { type: "error", code: "notJoined", message: "join first" });
+					return;
+				}
+				const playerId = ws.data.playerId;
+
+				if (msg.type === "battleAck") {
+					room.battleAck(playerId, now());
+					reactToTransitions(roomId);
+					return;
+				}
+
+				// Planning / commander commands all carry a cmdId.
+				const outcome = applyCommand(room, playerId, msg, now());
+				if (!outcome.ok) {
+					send(ws, {
+						type: "cmdRejected",
+						cmdId: msg.cmdId,
+						code: outcome.code,
+						message: outcome.message,
+					});
+					return;
+				}
+				const seat = ws.data.seat;
+				if (seat !== null) {
+					send(ws, {
+						type: "cmdAccepted",
+						cmdId: msg.cmdId,
+						match: room.snapshotFor(seat),
+					});
+				}
+				reactToTransitions(roomId);
+			},
+			close(ws: MatchSocket) {
+				socketsByPlayer.delete(ws.data.playerId);
+				const roomId = ws.data.roomId;
+				if (roomId === null) return;
+				const room = rooms.get(roomId);
+				if (!room) return;
+				room.disconnect(ws.data.playerId);
+				if (room.isEmpty) {
+					rooms.delete(roomId);
+					lastPhase.delete(roomId);
+				} else {
+					broadcastPhase(roomId);
+				}
+			},
+		},
+	});
+
+	function handleJoin(
+		ws: MatchSocket,
+		roomId: string,
+		playerName: string,
+		resumeToken?: string,
+	): void {
+		if (ws.data.roomId !== null) {
+			send(ws, {
+				type: "error",
+				code: "alreadyJoined",
+				message: "already joined",
+			});
+			return;
+		}
+		let room = rooms.get(roomId);
+		if (!room) {
+			room = new MatchRoom(
+				roomId,
+				catalog,
+				() => `rt-${roomId}-${tokenCounter++}`,
+			);
+			rooms.set(roomId, room);
+			lastPhase.set(roomId, room.currentPhase);
+		}
+		const seated = room.join(ws.data.playerId, playerName, now(), resumeToken);
+		if (!seated) {
+			send(ws, { type: "error", code: "roomFull", message: "room is full" });
+			return;
+		}
+		ws.data.roomId = roomId;
+		ws.data.seat = seated.seat;
+		socketsByPlayer.set(ws.data.playerId, ws);
+		ws.subscribe(topic(roomId));
+
+		send(ws, {
+			type: "welcome",
+			seat: seated.seat,
+			resumeToken: seated.resumeToken,
+			catalogJson: canonicalJson,
+			catalogHash: catalog.hash,
+			matchConfig: room.matchConfig(),
+			match: room.snapshotFor(seated.seat),
+		});
+		reactToTransitions(roomId);
+	}
+
+	// Deadline ticker: advance every room's phase machine on schedule.
+	let ticker: ReturnType<typeof setInterval> | null = null;
+	const tickMs = options.tickMs ?? 250;
+	if (tickMs > 0) {
+		ticker = setInterval(() => {
+			const t = now();
+			for (const [roomId, room] of rooms) {
+				if (room.tick(t)) reactToTransitions(roomId);
+			}
+		}, tickMs);
+	}
+
+	return {
+		server,
+		rooms,
+		catalog,
+		stop: () => {
+			if (ticker) clearInterval(ticker);
+			server.stop(true);
+		},
+	};
+}
+
+function applyCommand(
+	room: MatchRoom,
+	playerId: string,
+	msg: Extract<
+		ReturnType<typeof parseClientMessageV2>,
+		{ ok: true }
+	>["message"],
+	now: number,
+): CommandOutcome {
+	switch (msg.type) {
+		case "pickCommander":
+			return room.pickCommander(playerId, msg.commanderId, now);
+		case "buySquad":
+			return room.buySquad(
+				playerId,
+				msg.unitId,
+				msg.anchor.row,
+				msg.anchor.col,
+				msg.orientation,
+			);
+		case "moveSquad":
+			return room.moveSquad(
+				playerId,
+				msg.cardId,
+				msg.anchor.row,
+				msg.anchor.col,
+				msg.orientation,
+			);
+		case "sellSquad":
+			return room.sellSquad(playerId, msg.cardId);
+		case "unlockUnit":
+			return room.unlockUnit(playerId, msg.unitId);
+		case "buyTech":
+			return room.buyTech(playerId, msg.unitId, msg.techId);
+		case "buyLevel":
+			return room.buyLevel(playerId, msg.cardId);
+		case "setReady":
+			return room.setReady(playerId, msg.ready, now);
+		default:
+			return {
+				ok: false,
+				code: "badMessage",
+				message: "not a planning command",
+			};
+	}
+}
+
+function describeResult(winnerSeat: Seat | null): string {
+	if (winnerSeat === null) return "draw — both sides take survivor damage";
+	return `seat ${winnerSeat} wins the round`;
+}

--- a/core/types/src/index.ts
+++ b/core/types/src/index.ts
@@ -1,2 +1,3 @@
 export * from "./protocol";
 export * from "./catalog-schema";
+export * from "./protocol-v2";

--- a/core/types/src/protocol-v2.ts
+++ b/core/types/src/protocol-v2.ts
@@ -1,0 +1,440 @@
+import { z } from "zod";
+import { orientationSchema } from "./catalog-schema";
+
+/**
+ * Wire protocol V2 — the Mechabellum-style match loop (design doc §8).
+ *
+ * Replaces the V1 placement demo (protocol.ts) for real matches. JSON over
+ * WebSocket text frames, discriminated by `type`. The C# BattleServer (M5)
+ * ports the MatchRoom reducer against this exact contract; the only difference
+ * the client sees at cutover is that `battleLog` starts appearing.
+ *
+ * Coordinates: `row` = world-X (0..board.w-1, the wide/lateral axis),
+ * `col` = world-Z (0..board.h-1, the deep axis). Anchor = footprint min corner.
+ */
+
+export const PROTOCOL_VERSION = 2;
+
+export const seatSchema = z.union([z.literal(0), z.literal(1)]);
+export type Seat = z.infer<typeof seatSchema>;
+
+// ---------------------------------------------------------------------------
+// Blueprint & state on the wire (member layout is a pure function of the
+// catalog; the wire never enumerates members).
+// ---------------------------------------------------------------------------
+
+/** A purchased placement in a player's army blueprint. */
+export const squadCardSchema = z
+	.object({
+		cardId: z.string(),
+		unitId: z.string(),
+		anchor: z.object({ row: z.number().int(), col: z.number().int() }).strict(),
+		orientation: orientationSchema,
+		level: z.number().int().min(1),
+		xp: z.number().nonnegative(),
+		/** Round the card was purchased (for this-round free sell/revert). */
+		purchasedRound: z.number().int().nonnegative(),
+		/** Total coin invested (deploy + level-ups), for survivor valuation. */
+		invested: z.number().int().nonnegative(),
+	})
+	.strict();
+export type SquadCard = z.infer<typeof squadCardSchema>;
+
+/** Per-unit-type tech/unlock progression for one seat. */
+export const seatTechStateSchema = z
+	.object({
+		unlockedUnits: z.array(z.string()),
+		purchasedTechs: z.array(z.string()),
+		/** unitId → next tech price for that type (escalates on each purchase). */
+		techPriceByUnit: z.record(z.string(), z.number().int()),
+	})
+	.strict();
+export type SeatTechState = z.infer<typeof seatTechStateSchema>;
+
+/** The full server-authoritative view of ONE seat (its own private state). */
+export const seatViewSchema = z
+	.object({
+		seat: seatSchema,
+		playerName: z.string(),
+		connected: z.boolean(),
+		commanderId: z.string().nullable(),
+		hp: z.number().int(),
+		coin: z.number().int(),
+		deploysRemaining: z.number().int(),
+		unlocksRemaining: z.number().int(),
+		ready: z.boolean(),
+		cards: z.array(squadCardSchema),
+		tech: seatTechStateSchema,
+	})
+	.strict();
+export type SeatView = z.infer<typeof seatViewSchema>;
+
+/** The opponent as last revealed (end of previous round) — no hidden info. */
+export const opponentViewSchema = z
+	.object({
+		seat: seatSchema,
+		playerName: z.string(),
+		connected: z.boolean(),
+		commanderId: z.string().nullable(),
+		hp: z.number().int(),
+		/** Revealed army from the last plan-lock (empty before round 1 battle). */
+		cards: z.array(squadCardSchema),
+	})
+	.strict();
+export type OpponentView = z.infer<typeof opponentViewSchema>;
+
+export const phaseSchema = z.enum([
+	"lobby",
+	"commanderPick",
+	"planning",
+	"battle",
+	"results",
+	"matchEnded",
+]);
+export type Phase = z.infer<typeof phaseSchema>;
+
+/** matchConfig is derived from catalog MatchRules; the essentials the client needs. */
+export const matchConfigSchema = z
+	.object({
+		board: z.object({ w: z.number().int(), h: z.number().int() }).strict(),
+		deploysPerRound: z.number().int(),
+		unlocksPerRound: z.number().int(),
+		incomePerRoundIncrement: z.number().int(),
+		deploySeconds: z.number().int(),
+		battleSeconds: z.number().int(),
+		commanderPickSeconds: z.number().int(),
+		commandersOffered: z.number().int(),
+	})
+	.strict();
+export type MatchConfig = z.infer<typeof matchConfigSchema>;
+
+/** A complete match snapshot for one seat (own private view + opponent public). */
+export const matchSnapshotSchema = z
+	.object({
+		phase: phaseSchema,
+		round: z.number().int(),
+		/** Server epoch ms when the current phase's deadline fires (0 = none). */
+		phaseDeadline: z.number().int(),
+		commanderOffers: z.array(z.string()),
+		own: seatViewSchema,
+		opponent: opponentViewSchema.nullable(),
+	})
+	.strict();
+export type MatchSnapshot = z.infer<typeof matchSnapshotSchema>;
+
+// ---------------------------------------------------------------------------
+// Client → server
+// ---------------------------------------------------------------------------
+
+export const joinV2Schema = z
+	.object({
+		type: z.literal("join"),
+		roomId: z.string().min(1).max(64),
+		playerName: z.string().min(1).max(32),
+		protocolVersion: z.number().int(),
+		resumeToken: z.string().optional(),
+		catalogHash: z.string().optional(),
+	})
+	.strict();
+
+export const pickCommanderSchema = z
+	.object({
+		type: z.literal("pickCommander"),
+		cmdId: z.string(),
+		commanderId: z.string(),
+	})
+	.strict();
+
+const anchor = z
+	.object({ row: z.number().int(), col: z.number().int() })
+	.strict();
+
+export const buySquadSchema = z
+	.object({
+		type: z.literal("buySquad"),
+		cmdId: z.string(),
+		unitId: z.string(),
+		anchor,
+		orientation: orientationSchema.default("north"),
+	})
+	.strict();
+
+export const moveSquadSchema = z
+	.object({
+		type: z.literal("moveSquad"),
+		cmdId: z.string(),
+		cardId: z.string(),
+		anchor,
+		orientation: orientationSchema.default("north"),
+	})
+	.strict();
+
+export const sellSquadSchema = z
+	.object({
+		type: z.literal("sellSquad"),
+		cmdId: z.string(),
+		cardId: z.string(),
+	})
+	.strict();
+
+export const unlockUnitSchema = z
+	.object({
+		type: z.literal("unlockUnit"),
+		cmdId: z.string(),
+		unitId: z.string(),
+	})
+	.strict();
+
+export const buyTechSchema = z
+	.object({
+		type: z.literal("buyTech"),
+		cmdId: z.string(),
+		unitId: z.string(),
+		techId: z.string(),
+	})
+	.strict();
+
+export const buyLevelSchema = z
+	.object({
+		type: z.literal("buyLevel"),
+		cmdId: z.string(),
+		cardId: z.string(),
+	})
+	.strict();
+
+export const setReadySchema = z
+	.object({
+		type: z.literal("setReady"),
+		cmdId: z.string(),
+		ready: z.boolean(),
+	})
+	.strict();
+
+export const battleAckSchema = z
+	.object({ type: z.literal("battleAck") })
+	.strict();
+
+export const pingV2Schema = z.object({ type: z.literal("ping") }).strict();
+
+export const clientMessageV2Schema = z.discriminatedUnion("type", [
+	joinV2Schema,
+	pickCommanderSchema,
+	buySquadSchema,
+	moveSquadSchema,
+	sellSquadSchema,
+	unlockUnitSchema,
+	buyTechSchema,
+	buyLevelSchema,
+	setReadySchema,
+	battleAckSchema,
+	pingV2Schema,
+]);
+export type ClientMessageV2 = z.infer<typeof clientMessageV2Schema>;
+export type JoinV2 = z.infer<typeof joinV2Schema>;
+export type PickCommander = z.infer<typeof pickCommanderSchema>;
+export type BuySquad = z.infer<typeof buySquadSchema>;
+export type MoveSquad = z.infer<typeof moveSquadSchema>;
+export type SellSquad = z.infer<typeof sellSquadSchema>;
+export type UnlockUnit = z.infer<typeof unlockUnitSchema>;
+export type BuyTech = z.infer<typeof buyTechSchema>;
+export type BuyLevel = z.infer<typeof buyLevelSchema>;
+export type SetReady = z.infer<typeof setReadySchema>;
+
+/** A command carrying a cmdId (everything except join/battleAck/ping). */
+export type PlanningCommand =
+	| PickCommander
+	| BuySquad
+	| MoveSquad
+	| SellSquad
+	| UnlockUnit
+	| BuyTech
+	| BuyLevel
+	| SetReady;
+
+// ---------------------------------------------------------------------------
+// Server → client
+// ---------------------------------------------------------------------------
+
+export const cmdRejectCodeSchema = z.enum([
+	"badMessage",
+	"notJoined",
+	"wrongPhase",
+	"notYourTurn",
+	"unknownCommander",
+	"commanderAlreadyPicked",
+	"unknownUnit",
+	"notUnlocked",
+	"insufficientFunds",
+	"noDeploysLeft",
+	"noUnlocksLeft",
+	"alreadyUnlocked",
+	"outOfBounds",
+	"outsideOwnHalf",
+	"tileOccupied",
+	"unknownCard",
+	"notThisRoundPurchase",
+	"unknownTech",
+	"techAlreadyOwned",
+	"xpNotReady",
+	"internal",
+]);
+export type CmdRejectCode = z.infer<typeof cmdRejectCodeSchema>;
+
+export const welcomeV2Schema = z
+	.object({
+		type: z.literal("welcome"),
+		seat: seatSchema,
+		resumeToken: z.string(),
+		catalogJson: z.string(),
+		catalogHash: z.string(),
+		matchConfig: matchConfigSchema,
+		match: matchSnapshotSchema.nullable(),
+	})
+	.strict();
+
+export const phaseMessageSchema = z
+	.object({
+		type: z.literal("phase"),
+		match: matchSnapshotSchema,
+	})
+	.strict();
+
+export const cmdAcceptedSchema = z
+	.object({
+		type: z.literal("cmdAccepted"),
+		cmdId: z.string(),
+		match: matchSnapshotSchema,
+	})
+	.strict();
+
+export const cmdRejectedSchema = z
+	.object({
+		type: z.literal("cmdRejected"),
+		cmdId: z.string(),
+		code: cmdRejectCodeSchema,
+		message: z.string(),
+	})
+	.strict();
+
+export const revealSnapshotSchema = z
+	.object({
+		type: z.literal("revealSnapshot"),
+		round: z.number().int(),
+		armies: z.array(
+			z.object({ seat: seatSchema, cards: z.array(squadCardSchema) }).strict(),
+		),
+	})
+	.strict();
+
+export const battleStartedSchema = z
+	.object({
+		type: z.literal("battleStarted"),
+		round: z.number().int(),
+		startAtServerMs: z.number().int(),
+		/** Present once the real sim exists (M5); absent in the stub era. */
+		hasBattleLog: z.boolean(),
+	})
+	.strict();
+
+export const battleLogSchema = z
+	.object({
+		type: z.literal("battleLog"),
+		round: z.number().int(),
+		/** Opaque to the protocol; the sim's event log (M5). */
+		log: z.unknown(),
+	})
+	.strict();
+
+export const roundResultSchema = z
+	.object({
+		type: z.literal("roundResult"),
+		round: z.number().int(),
+		winnerSeat: seatSchema.nullable(),
+		hpDamage: z.array(
+			z.object({ seat: seatSchema, amount: z.number().int() }).strict(),
+		),
+		hp: z.array(z.object({ seat: seatSchema, hp: z.number().int() }).strict()),
+		summary: z.string(),
+	})
+	.strict();
+
+export const matchEndedSchema = z
+	.object({
+		type: z.literal("matchEnded"),
+		winnerSeat: seatSchema.nullable(),
+		finalHp: z.array(
+			z.object({ seat: seatSchema, hp: z.number().int() }).strict(),
+		),
+	})
+	.strict();
+
+export const errorV2Schema = z
+	.object({
+		type: z.literal("error"),
+		code: z.string(),
+		message: z.string(),
+	})
+	.strict();
+
+export const pongV2Schema = z.object({ type: z.literal("pong") }).strict();
+
+export const serverMessageV2Schema = z.discriminatedUnion("type", [
+	welcomeV2Schema,
+	phaseMessageSchema,
+	cmdAcceptedSchema,
+	cmdRejectedSchema,
+	revealSnapshotSchema,
+	battleStartedSchema,
+	battleLogSchema,
+	roundResultSchema,
+	matchEndedSchema,
+	errorV2Schema,
+	pongV2Schema,
+]);
+export type ServerMessageV2 = z.infer<typeof serverMessageV2Schema>;
+export type WelcomeV2 = z.infer<typeof welcomeV2Schema>;
+export type PhaseMessage = z.infer<typeof phaseMessageSchema>;
+export type CmdAccepted = z.infer<typeof cmdAcceptedSchema>;
+export type CmdRejected = z.infer<typeof cmdRejectedSchema>;
+export type RevealSnapshot = z.infer<typeof revealSnapshotSchema>;
+export type BattleStarted = z.infer<typeof battleStartedSchema>;
+export type RoundResult = z.infer<typeof roundResultSchema>;
+export type MatchEnded = z.infer<typeof matchEndedSchema>;
+
+// ---------------------------------------------------------------------------
+// Parsing helpers
+// ---------------------------------------------------------------------------
+
+export type ParseResultV2<T> =
+	| { ok: true; message: T }
+	| { ok: false; error: string };
+
+function parseJson(raw: string): { ok: true; value: unknown } | { ok: false } {
+	try {
+		return { ok: true, value: JSON.parse(raw) };
+	} catch {
+		return { ok: false };
+	}
+}
+
+export function parseClientMessageV2(
+	raw: string,
+): ParseResultV2<ClientMessageV2> {
+	const json = parseJson(raw);
+	if (!json.ok) return { ok: false, error: "invalid JSON" };
+	const result = clientMessageV2Schema.safeParse(json.value);
+	if (!result.success)
+		return { ok: false, error: z.prettifyError(result.error) };
+	return { ok: true, message: result.data };
+}
+
+export function parseServerMessageV2(
+	raw: string,
+): ParseResultV2<ServerMessageV2> {
+	const json = parseJson(raw);
+	if (!json.ok) return { ok: false, error: "invalid JSON" };
+	const result = serverMessageV2Schema.safeParse(json.value);
+	if (!result.success)
+		return { ok: false, error: z.prettifyError(result.error) };
+	return { ok: true, message: result.data };
+}

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -205,4 +205,56 @@ headlessly):**
 - `.meta` files for `StreamingAssets/catalog.json`, the Core package's
   `package.json`/`asmdef` — Unity generates these on import.
 
+## M3 — Multiplayer planning loop 🟡 (server + reducer done; Unity client deferred)
+
+**Built (headless, verified)**
+- **Protocol V2** (`core/types/src/protocol-v2.ts`, `PROTOCOL_VERSION = 2`) — the
+  full match-loop wire contract: client→server `join` (with resumeToken/catalogHash),
+  `pickCommander`, `buySquad`, `moveSquad`, `sellSquad`, `unlockUnit`, `buyTech`,
+  `buyLevel`, `setReady`, `battleAck`, `ping`; server→client `welcome` (seat +
+  exact catalog bytes + matchConfig + resumable snapshot), `phase`, `cmdAccepted`,
+  `cmdRejected`, `revealSnapshot`, `battleStarted`, `battleLog`, `roundResult`,
+  `matchEnded`, `error`, `pong`. Per-seat `SeatView` (private) vs `OpponentView`
+  (only last-revealed army). Coexists with V1 (no name collisions).
+- **MatchRoom reducer** (`apps/game-server/src/matchRoom.ts`) — the pure,
+  transport-free, clock-injected phase machine (lobby → commanderPick →
+  planning(N) → battle → results → … → matchEnded). No `Date.now()`/`Math.random()`
+  (deterministic; the executable spec the M5 C# port follows). Full economy
+  (income 200×N + commander mods, deploy/unlock slots, tech escalation +200,
+  level pricing), hidden simultaneous planning via per-seat views, catalog-driven
+  placement (bounds/own-half/overlap), reconnect via resumeToken, and the **stub
+  battle resolver** (invested-value comparison → prorated survivor HP damage,
+  floored). Commander HP is the player HP pool; starting buildings + commander
+  units materialize on round 1.
+- **Match server** (`apps/game-server/src/matchServer.ts`) — protocol V2 over
+  `Bun.serve` WebSockets driving MatchRoom, with a deadline ticker advancing every
+  room's phase machine, per-seat private snapshots, reveal/battleStarted/roundResult/
+  matchEnded broadcasts, and `welcome` shipping the exact catalog bytes. New
+  `dev:match`/`start:match` scripts and a second compiled binary (`dist/match-server`)
+  that embeds the catalog. `battleStarted.hasBattleLog = false` (stub era).
+- **Tests**: **19 MatchRoom reducer tests** (lobby/commanderPick, economy,
+  hidden planning, stub battle + result, **a full match played to HP zero** via
+  both explicit acks and pure deadline ticks, reconnect) + **6 match-server
+  integration tests** over a real socket (welcome + catalog bytes, commanderPick,
+  a full round pick→buy→ready→reveal→battleStarted→ack→roundResult, hidden-planning
+  leak check, command rejection). Total game-server suite: **53/53 green**.
+
+**Verified**
+- Full hidden-planning match reaches `matchEnded` with the loser's HP at 0 (the
+  M3 "Done when"), driven both by acks and by deadline ticks alone.
+- Match-server binary boots; `/health` reports `protocolVersion:2` + catalog
+  hash + 32×48 board.
+- `bunx turbo run check-types test build` → green; dotnet 18/18 green;
+  `format:check` clean.
+
+**⏭️ Deferred to a human (Unity Editor / device):**
+- The **Unity match client**: commander-pick screen, shop panel, drag placement
+  with footprint validity, ready/opponent-ready indicator, reveal beat, results
+  panel, match-end — all Unity UI. `GameServerClient` → protocol V2 + Newtonsoft,
+  `MatchClient` store, resumeToken in PlayerPrefs.
+- The **camera rig** (`MatchCameraRig`) + touch gestures (pan/pinch/rotate).
+- **Forge v1** (full form editing incl. formation/commander editors) — a browser
+  app that can be built later; v0 (browse/validate/build) already ships.
+- Running two editor instances (Multiplayer Play Mode) to play a match on screen.
+
 <!-- Subsequent milestones appended as they complete. -->


### PR DESCRIPTION
## M3 — Multiplayer planning loop

The headless half of M3: **protocol V2**, the **MatchRoom reducer**, and the **match server**. The Unity match client + camera rig are deferred to a human (see `docs/PROGRESS.md`).

**Done when: a full hidden-planning match plays to HP zero (no combat yet).** ✅ — proven by the MatchRoom test suite (both via explicit acks and via pure deadline ticks) and the match-server socket integration tests.

### What was done
- **Protocol V2** (`core/types/src/protocol-v2.ts`) — the full match-loop contract: `join` (resumeToken/catalogHash) / `pickCommander` / `buySquad` / `moveSquad` / `sellSquad` / `unlockUnit` / `buyTech` / `buyLevel` / `setReady` / `battleAck` → `welcome` (seat + **exact catalog bytes** + matchConfig + resumable snapshot) / `phase` / `cmdAccepted` / `cmdRejected` / `revealSnapshot` / `battleStarted` / `battleLog` / `roundResult` / `matchEnded` / `error` / `pong`. Per-seat `SeatView` (private) vs `OpponentView` (last-revealed army only). Coexists with V1.
- **MatchRoom reducer** (`matchRoom.ts`) — the pure, transport-free, **clock-injected** phase machine (lobby → commanderPick → planning(N) → battle → results → matchEnded). No `Date.now()`/`Math.random()` — deterministic, the executable spec the M5 C# port follows. Full economy (income 200×N + commander mods, deploy/unlock slots, tech escalation +200, level pricing), hidden simultaneous planning via per-seat views, catalog-driven placement (bounds/own-half/overlap), reconnect via resumeToken, and the **stub battle resolver** (invested-value → prorated survivor HP damage).
- **Match server** (`matchServer.ts`) — protocol V2 over `Bun.serve` WebSockets driving MatchRoom, with a deadline ticker, per-seat private snapshots, reveal/battleStarted/roundResult/matchEnded broadcasts, and `welcome` shipping the exact catalog bytes. New `dev:match`/`start:match` scripts + a second compiled binary (`dist/match-server`) that embeds the catalog.

### How it was verified
- **19 MatchRoom reducer tests** — lobby/commanderPick, economy, hidden planning, stub battle + result, **a full match played to HP zero** (both explicit acks and pure deadline ticks), reconnect.
- **6 match-server integration tests** over a real socket — welcome + catalog bytes, commanderPick, a full round (pick→buy→ready→reveal→battleStarted→ack→roundResult), hidden-planning leak check, command rejection.
- Full game-server suite **53/53 green**; match-server binary `/health` reports `protocolVersion:2` + catalog hash + 32×48; `turbo check-types test build` green; dotnet 18/18 green; `format:check` clean.

### ⏭️ Deferred to a human (Unity Editor / device)
- The Unity match client (commander pick, shop, drag placement, ready indicator, reveal beat, results, match end), `GameServerClient` → V2 + Newtonsoft, `MatchClient` store, resumeToken in PlayerPrefs.
- The camera rig + touch gestures.
- Forge v1 full form editing (v0 browse/validate/build already ships).
- Two-editor Multiplayer Play Mode playtest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEQ5sQKX7Mid8FfmzBJv6i