### PR TITLE
M5 — BattleServer cutover (C# match loop + real battles + SQLite)

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -311,4 +311,56 @@ headlessly):**
   needs them yet; they ride the established effect-kind seam when content does
   (design doc §11.6).
 
+## M5 — BattleServer cutover ✅ (deploy to a VPS is the only human step)
+
+**Built (headless, verified)**
+- **Protocol V2 C# DTOs** (`BoardGame.Core/Runtime/Match/ProtocolV2.cs`) — the
+  hand-maintained C# mirror of `protocol-v2.ts`: client-message parsing
+  (discriminated on `type` via `ClientMessageV2.Parse`), state DTOs, and
+  server-message builders.
+- **MatchRoom ported to C#** (`Runtime/Match/MatchRoom.cs`) — a faithful port of
+  the Bun reducer, structurally identical so the ported test suite confirms
+  equivalence. Same phase machine / economy / hidden planning / catalog-driven
+  placement / reconnect. The one behavioral change: at plan-lock it **runs the
+  Core sim** and exposes the real event log (`LastBattleLog`). Adds
+  `CaptureState`/`RestoreState` + a `MatchRoomSnapshot` DTO for persistence.
+- **BattleServer** (`dotnet/BoardGame.BattleServer`) — ASP.NET Core minimal host:
+  `/health`, a `/ws` protocol-V2 endpoint (shared `WebSocketEndpoint.Map`), a
+  `PeriodicTimer` deadline ticker (`TickerService`), and a **per-room lock**
+  making each room a single-threaded actor (no command-interleave races). At
+  plan-lock it ships `revealSnapshot` + `battleStarted` + **`battleLog`** +
+  `roundResult`. Newtonsoft throughout (matches the wire + dodges a
+  System.Text.Json PipeWriter mismatch under roll-forward).
+- **SQLite persistence** (`RoomStore.cs`) — `IRoomStore` with a `SqliteRoomStore`
+  (one upserted row per room at every transition/command + a finished-match
+  archive table) and an `InMemoryRoomStore` for tests. `BOARDGAME_DB` selects
+  SQLite; otherwise in-memory.
+- **Ported conformance suite** (`BoardGame.BattleServer.Tests`, real Kestrel on
+  an ephemeral port + real `ClientWebSocket`): `/health` protocol v2, welcome
+  with catalog bytes, a **full round producing a real battleLog** (the cutover
+  signal — `hasBattleLog: true`), command rejection, plus **restart-resume**
+  (capture/restore round-trip, SQLite survives a reopen with reconnect tokens
+  intact, hub resumes a room from the store).
+
+**Verified**
+- `dotnet test` → **44/44 green** (37 Core incl. 11 ported MatchRoom + 7
+  BattleServer integration); **stable across 6+ isolated and 4+ full-solution
+  runs** (the earlier flake was a racing-seat test bug, now fixed via sequential
+  seat-aware joins + the per-room actor lock).
+- The real BattleServer binary boots with SQLite, `/health` returns protocol v2
+  + the embedded-catalog hash + creates the DB.
+- `dotnet publish -c Release -r <rid> --self-contained` produces a single
+  deployable binary.
+- `turbo run build test --filter=battle-server` green; TS pipeline green; format
+  clean.
+
+**⏭️ Deferred to a human:**
+- **VPS deployment** (Hetzner/Fly, credentials + DNS) — the self-contained
+  binary and Docker path are ready; publishing to a host is an ops step.
+- **Retiring `apps/game-server` + retargeting `bun dev`** — kept intentionally:
+  the Bun match server is the reference spec (its tests still gate CI) and the
+  cutover to the .NET server is a deploy/ops switch, not a code deletion. The
+  client sees the same protocol V2; only `battleLog` now appears.
+- Playing a real cross-network match on two phones against the deployed server.
+
 <!-- Subsequent milestones appended as they complete. -->

--- a/dotnet/BoardGame.BattleServer.Tests/AssemblyInfo.cs
+++ b/dotnet/BoardGame.BattleServer.Tests/AssemblyInfo.cs
@@ -1,0 +1,4 @@
+// Each integration test boots a full ASP.NET Core host; running them in parallel
+// (especially alongside the Core.Tests assembly) causes startup-latency timeouts.
+// Serialize them within this assembly for stable timing.
+[assembly: Xunit.CollectionBehavior(DisableTestParallelization = true)]

--- a/dotnet/BoardGame.BattleServer.Tests/BoardGame.BattleServer.Tests.csproj
+++ b/dotnet/BoardGame.BattleServer.Tests/BoardGame.BattleServer.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!--
+    Integration tests for the production battle server: boot the ASP.NET Core
+    host in-process (WebApplicationFactory) and drive it over a real WebSocket,
+    exercising the ported protocol V2 + MatchRoom end to end. Also the
+    restart-resume test.
+  -->
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <LangVersion>latest</LangVersion>
+    <RollForward>Major</RollForward>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <!-- Needed to use WebApplication/Kestrel directly from a non-Web test SDK. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../BoardGame.BattleServer/BoardGame.BattleServer.csproj" />
+    <ProjectReference Include="../BoardGame.Core/BoardGame.Core.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/dotnet/BoardGame.BattleServer.Tests/MatchServerIntegrationTests.cs
+++ b/dotnet/BoardGame.BattleServer.Tests/MatchServerIntegrationTests.cs
@@ -1,0 +1,222 @@
+using System.Net.WebSockets;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace BoardGame.BattleServer.Tests
+{
+    /// <summary>
+    /// Ported conformance suite over a REAL socket (Kestrel on an ephemeral port
+    /// + a real ClientWebSocket — not TestHost, whose in-memory transport
+    /// deadlocks on cross-connection broadcasts). The client sees protocol V2
+    /// exactly as against the Bun server, except battleLog now appears — proving
+    /// the .NET cutover is a server swap, not a client migration.
+    /// </summary>
+    public class MatchServerIntegrationTests
+    {
+        /// <summary>Boots the real Program host on 127.0.0.1:0 and returns its base URL.</summary>
+        private static async Task<(WebApplication app, string baseUrl)> StartHost()
+        {
+            // Build the same app the production Program builds, but bind an
+            // ephemeral loopback port. We replicate Program's wiring here because
+            // Program.Main runs app.Run() (blocking); this gives us StartAsync.
+            var (catalog, catalogJson) = CatalogSource.Load();
+            var builder = WebApplication.CreateBuilder();
+            builder.WebHost.UseUrls("http://127.0.0.1:0");
+            builder.Logging.ClearProviders();
+            var hub = new MatchHub(catalog, catalogJson, new InMemoryRoomStore());
+            builder.Services.AddSingleton(hub);
+
+            var app = builder.Build();
+            app.UseWebSockets();
+            app.MapGet("/health", () => Results.Content(
+                Newtonsoft.Json.JsonConvert.SerializeObject(new
+                {
+                    status = "ok",
+                    protocolVersion = BoardGame.Core.Match.ProtocolV2.Version,
+                    catalogHash = hub.CatalogHash,
+                }), "application/json"));
+            WebSocketEndpoint.Map(app, hub);
+
+            await app.StartAsync();
+            var addr = app.Urls.First();
+            return (app, addr);
+        }
+
+        // A background-reader client: a receive loop drains every frame into a
+        // queue, so Until() never misses a message due to read ordering and
+        // surfaces an unexpected cmdRejected instead of hanging on it.
+        private sealed class Ws : IDisposable
+        {
+            private readonly ClientWebSocket _ws = new();
+            private readonly System.Collections.Concurrent.ConcurrentQueue<JObject> _queue = new();
+
+            public async Task Connect(string baseUrl)
+            {
+                var uri = new Uri(baseUrl.Replace("http://", "ws://") + "/ws");
+                await _ws.ConnectAsync(uri, CancellationToken.None);
+                _ = ReceiveLoop();
+            }
+
+            private async Task ReceiveLoop()
+            {
+                var buffer = new byte[64 * 1024];
+                try
+                {
+                    while (_ws.State == WebSocketState.Open)
+                    {
+                        using var ms = new MemoryStream();
+                        WebSocketReceiveResult r;
+                        do { r = await _ws.ReceiveAsync(buffer, CancellationToken.None); ms.Write(buffer, 0, r.Count); }
+                        while (!r.EndOfMessage);
+                        if (r.MessageType == WebSocketMessageType.Close) break;
+                        _queue.Enqueue(JObject.Parse(Encoding.UTF8.GetString(ms.ToArray())));
+                    }
+                }
+                catch { /* closed */ }
+            }
+
+            public async Task Send(object msg)
+            {
+                var text = Newtonsoft.Json.JsonConvert.SerializeObject(msg);
+                await _ws.SendAsync(Encoding.UTF8.GetBytes(text), WebSocketMessageType.Text, true, CancellationToken.None);
+            }
+
+            public async Task<JObject> Until(string type, int timeoutMs = 30000)
+            {
+                var deadline = DateTime.UtcNow.AddMilliseconds(timeoutMs);
+                while (DateTime.UtcNow < deadline)
+                {
+                    if (_queue.TryDequeue(out var m))
+                    {
+                        var t = (string?)m["type"];
+                        if (t == type) return m;
+                        // A cmdRejected we weren't waiting for means a test-setup bug
+                        // (e.g. an invalid placement) — fail fast instead of hanging.
+                        if (t == "cmdRejected" && type != "cmdRejected")
+                            throw new Xunit.Sdk.XunitException($"unexpected cmdRejected: {m["code"]} {m["message"]}");
+                        continue;
+                    }
+                    await Task.Delay(5);
+                }
+                throw new TimeoutException($"never saw {type}");
+            }
+
+            public void Dispose() => _ws.Dispose();
+        }
+
+        [Fact]
+        public async Task HealthAdvertisesProtocolV2()
+        {
+            var (app, baseUrl) = await StartHost();
+            try
+            {
+                using var http = new HttpClient();
+                var body = await http.GetStringAsync(baseUrl + "/health");
+                var json = JObject.Parse(body);
+                Assert.Equal("ok", (string?)json["status"]);
+                Assert.Equal(2, (int)json["protocolVersion"]!);
+                Assert.False(string.IsNullOrEmpty((string?)json["catalogHash"]));
+            }
+            finally { await app.StopAsync(); }
+        }
+
+        [Fact]
+        public async Task JoinReturnsWelcomeWithCatalogBytes()
+        {
+            var (app, baseUrl) = await StartHost();
+            try
+            {
+                using var a = new Ws();
+                await a.Connect(baseUrl);
+                await a.Send(new { type = "join", roomId = "r1", playerName = "Alice", protocolVersion = 2 });
+                var welcome = await a.Until("welcome");
+                Assert.Equal(0, (int)welcome["seat"]!);
+                Assert.True(((string)welcome["catalogJson"]!).Length > 100);
+                Assert.Equal(32, (int)welcome["matchConfig"]!["board"]!["w"]!);
+            }
+            finally { await app.StopAsync(); }
+        }
+
+        [Fact]
+        public async Task FullRoundProducesARealBattleLog()
+        {
+            var (app, baseUrl) = await StartHost();
+            try
+            {
+                using var a = new Ws();
+                using var b = new Ws();
+                // Join sequentially (await each welcome) so seat assignment is
+                // deterministic — a = seat 0, b = seat 1 — regardless of thread
+                // scheduling. Each then buys within ITS OWN half.
+                await a.Connect(baseUrl);
+                await a.Send(new { type = "join", roomId = "r2", playerName = "Alice", protocolVersion = 2 });
+                var aWelcome = await a.Until("welcome");
+                int aSeat = (int)aWelcome["seat"]!;
+
+                await b.Connect(baseUrl);
+                await b.Send(new { type = "join", roomId = "r2", playerName = "Bob", protocolVersion = 2 });
+                var bWelcome = await b.Until("welcome");
+                int bSeat = (int)bWelcome["seat"]!;
+
+                var aPhase = await a.Until("phase");
+                var bPhase = await b.Until("phase");
+                Assert.Equal("commanderPick", (string?)aPhase["match"]!["phase"]);
+
+                await a.Send(new { type = "pickCommander", cmdId = "a1", commanderId = (string)aPhase["match"]!["commanderOffers"]![0]! });
+                await b.Send(new { type = "pickCommander", cmdId = "b1", commanderId = (string)bPhase["match"]!["commanderOffers"]![0]! });
+                await a.Until("phase"); // planning
+
+                // Buy in each seat's own half: seat 0 near col 10, seat 1 near col 30.
+                int aCol = aSeat == 0 ? 10 : 30;
+                int bCol = bSeat == 0 ? 10 : 30;
+                await a.Send(new { type = "buySquad", cmdId = "a2", unitId = "archer", anchor = new { row = 0, col = aCol }, orientation = "north" });
+                await b.Send(new { type = "buySquad", cmdId = "b2", unitId = "footman", anchor = new { row = 0, col = bCol }, orientation = "north" });
+                await a.Until("cmdAccepted");
+                await b.Until("cmdAccepted");
+
+                await a.Send(new { type = "setReady", cmdId = "a3", ready = true });
+                await b.Send(new { type = "setReady", cmdId = "b3", ready = true });
+
+                var started = await a.Until("battleStarted");
+                Assert.True((bool)started["hasBattleLog"]!); // THE cutover signal
+                var log = await a.Until("battleLog");
+                Assert.NotNull(log["log"]);
+
+                await a.Send(new { type = "battleAck" });
+                await b.Send(new { type = "battleAck" });
+                var result = await a.Until("roundResult");
+                Assert.Equal(2, ((JArray)result["hp"]!).Count);
+            }
+            finally { await app.StopAsync(); }
+        }
+
+        [Fact]
+        public async Task RejectedCommandReturnsCmdRejected()
+        {
+            var (app, baseUrl) = await StartHost();
+            try
+            {
+                using var a = new Ws();
+                using var b = new Ws();
+                await a.Connect(baseUrl);
+                await a.Send(new { type = "join", roomId = "r3", playerName = "Alice", protocolVersion = 2 });
+                await a.Until("welcome");
+                await b.Connect(baseUrl);
+                await b.Send(new { type = "join", roomId = "r3", playerName = "Bob", protocolVersion = 2 });
+                await b.Until("welcome");
+                await a.Until("phase");
+                await a.Send(new { type = "pickCommander", cmdId = "x", commanderId = "notReal" });
+                var rej = await a.Until("cmdRejected");
+                Assert.Equal("unknownCommander", (string?)rej["code"]);
+            }
+            finally { await app.StopAsync(); }
+        }
+    }
+}

--- a/dotnet/BoardGame.BattleServer.Tests/PersistenceTests.cs
+++ b/dotnet/BoardGame.BattleServer.Tests/PersistenceTests.cs
@@ -1,0 +1,113 @@
+using System.IO;
+using System.Linq;
+using BoardGame.Core.Catalog;
+using BoardGame.Core.Match;
+using Xunit;
+
+namespace BoardGame.BattleServer.Tests
+{
+    /// <summary>
+    /// Restart-resume: a room persisted at phase transitions can be rehydrated
+    /// (as after a server restart) with its full state — blueprints, hp, coin,
+    /// tech, phase, round, resume tokens — intact.
+    /// </summary>
+    public class PersistenceTests
+    {
+        private static LoadedCatalog Catalog()
+        {
+            var (cat, _) = CatalogSource.Load();
+            return cat;
+        }
+
+        private static MatchRoom PlayIntoMidMatch(LoadedCatalog cat, out string token0)
+        {
+            var room = new MatchRoom("resume", cat, s => $"tok-resume-{s}");
+            room.Join("p0", "Alice", 0);
+            room.Join("p1", "Bob", 0);
+            room.PickCommander("p0", room.SnapshotFor(0).CommanderOffers[0], 0);
+            room.PickCommander("p1", room.SnapshotFor(1).CommanderOffers[0], 0);
+            room.BuySquad("p0", "footman", 0, 10, "north");
+            room.UnlockUnit("p0", "ballista");
+            token0 = "tok-resume-0";
+            return room;
+        }
+
+        [Fact]
+        public void CaptureRestoreRoundTripsState()
+        {
+            var cat = Catalog();
+            var room = PlayIntoMidMatch(cat, out _);
+            var snap = room.CaptureState();
+
+            var restored = new MatchRoom("resume", cat, s => $"fresh-{s}");
+            restored.RestoreState(snap);
+
+            Assert.Equal(room.CurrentPhase, restored.CurrentPhase);
+            Assert.Equal(room.CurrentRound, restored.CurrentRound);
+            var own = restored.SnapshotFor(0).Own;
+            Assert.Contains(own.Cards, c => c.UnitId == "footman");
+            Assert.Contains("ballista", own.Tech.UnlockedUnits);
+            // resume token preserved so the original player can reconnect
+            Assert.Equal(0, restored.SeatByResumeToken("tok-resume-0"));
+        }
+
+        [Fact]
+        public void SqliteStoreSurvivesAReopen()
+        {
+            var cat = Catalog();
+            var dbPath = Path.Combine(Path.GetTempPath(), $"bg-resume-{System.Guid.NewGuid():N}.db");
+            try
+            {
+                // "Before restart": play + persist.
+                using (var store = new SqliteRoomStore($"Data Source={dbPath}"))
+                {
+                    var room = PlayIntoMidMatch(cat, out _);
+                    store.Save("resume", room);
+                }
+
+                // "After restart": a brand-new store over the same file rehydrates.
+                using (var store2 = new SqliteRoomStore($"Data Source={dbPath}"))
+                {
+                    var loaded = store2.TryLoad("resume", cat, () => "tok-resume-x");
+                    Assert.NotNull(loaded);
+                    Assert.Equal(Phase.Planning, loaded!.CurrentPhase);
+                    var own = loaded.SnapshotFor(0).Own;
+                    Assert.Contains(own.Cards, c => c.UnitId == "footman");
+                    // the reconnect token round-trips
+                    Assert.Equal(0, loaded.SeatByResumeToken("tok-resume-0"));
+
+                    // ...and the reconnected player can resume playing.
+                    var rejoin = loaded.Join("p0-new", "Alice", 0, "tok-resume-0");
+                    Assert.NotNull(rejoin);
+                    Assert.Equal(0, rejoin!.Value.seat);
+                }
+            }
+            finally
+            {
+                if (File.Exists(dbPath)) File.Delete(dbPath);
+            }
+        }
+
+        [Fact]
+        public async System.Threading.Tasks.Task HubResumesARoomFromTheStoreOnRejoin()
+        {
+            var cat = Catalog();
+            var (_, json) = CatalogSource.Load();
+            var store = new InMemoryRoomStore();
+
+            // First hub: play into mid-match, persisting on each command.
+            var hub1 = new MatchHub(cat, json, store, () => 1000);
+            var conn0 = new Connection(_ => System.Threading.Tasks.Task.CompletedTask);
+            var conn1 = new Connection(_ => System.Threading.Tasks.Task.CompletedTask);
+            await hub1.HandleAsync(conn0, "{\"type\":\"join\",\"roomId\":\"z\",\"playerName\":\"A\",\"protocolVersion\":2}");
+            await hub1.HandleAsync(conn1, "{\"type\":\"join\",\"roomId\":\"z\",\"playerName\":\"B\",\"protocolVersion\":2}");
+
+            // A brand-new hub over the SAME store (a restart) resumes the room when
+            // a player rejoins — the room only exists in hub2 if TryLoad found it.
+            var hub2 = new MatchHub(cat, json, store, () => 2000);
+            var reconn = new Connection(_ => System.Threading.Tasks.Task.CompletedTask);
+            await hub2.HandleAsync(reconn, "{\"type\":\"join\",\"roomId\":\"z\",\"playerName\":\"A\",\"protocolVersion\":2}");
+            Assert.Equal(1, hub2.RoomCount);
+        }
+    }
+}

--- a/dotnet/BoardGame.BattleServer/BoardGame.BattleServer.csproj
+++ b/dotnet/BoardGame.BattleServer/BoardGame.BattleServer.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="8.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/dotnet/BoardGame.BattleServer/CatalogSource.cs
+++ b/dotnet/BoardGame.BattleServer/CatalogSource.cs
@@ -1,0 +1,37 @@
+using System;
+using System.IO;
+using BoardGame.Core.Catalog;
+
+namespace BoardGame.BattleServer
+{
+    /// <summary>
+    /// Loads the built catalog for the server. Prefers the BOARDGAME_CATALOG env
+    /// path; otherwise walks up from the binary to the committed
+    /// core/catalog/dist/catalog.json (dev/CI). Deployments set the env var to a
+    /// catalog shipped alongside the binary.
+    /// </summary>
+    public static class CatalogSource
+    {
+        public static (LoadedCatalog catalog, string canonicalJson) Load()
+        {
+            var path = Environment.GetEnvironmentVariable("BOARDGAME_CATALOG");
+            if (string.IsNullOrEmpty(path)) path = FindCommitted();
+            if (path == null || !File.Exists(path))
+                throw new FileNotFoundException("could not locate catalog.json; set BOARDGAME_CATALOG");
+            var json = File.ReadAllText(path);
+            return (CatalogLoader.Load(json), json);
+        }
+
+        private static string? FindCommitted()
+        {
+            var dir = new DirectoryInfo(AppContext.BaseDirectory);
+            while (dir != null)
+            {
+                var candidate = Path.Combine(dir.FullName, "core", "catalog", "dist", "catalog.json");
+                if (File.Exists(candidate)) return candidate;
+                dir = dir.Parent;
+            }
+            return null;
+        }
+    }
+}

--- a/dotnet/BoardGame.BattleServer/MatchHub.cs
+++ b/dotnet/BoardGame.BattleServer/MatchHub.cs
@@ -1,0 +1,243 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using BoardGame.Core.Catalog;
+using BoardGame.Core.Match;
+
+namespace BoardGame.BattleServer
+{
+    /// <summary>A live connection to one seat of one room.</summary>
+    public sealed class Connection
+    {
+        public string PlayerId { get; } = Guid.NewGuid().ToString();
+        public string? RoomId;
+        public int? Seat;
+        public Func<string, System.Threading.Tasks.Task> Send { get; }
+        public Connection(Func<string, System.Threading.Tasks.Task> send) { Send = send; }
+    }
+
+    /// <summary>
+    /// Owns the room registry and routes protocol-V2 messages to the ported C#
+    /// MatchRoom, mirroring apps/game-server/src/matchServer.ts. Rooms are driven
+    /// by a deadline ticker (Tick) and by client acks; each seat gets its own
+    /// private snapshot. At plan-lock the MatchRoom runs the Core sim and this hub
+    /// ships battleStarted + battleLog + roundResult. Persistence is delegated to
+    /// an IRoomStore so a restart can resume mid-match.
+    /// </summary>
+    public sealed class MatchHub
+    {
+        private readonly LoadedCatalog _catalog;
+        private readonly string _catalogJson;
+        private readonly IRoomStore _store;
+        private readonly Func<long> _now;
+
+        private readonly ConcurrentDictionary<string, MatchRoom> _rooms = new();
+        private readonly ConcurrentDictionary<string, string> _lastPhase = new();
+        // roomId → seat → connection
+        private readonly ConcurrentDictionary<string, Connection?[]> _seatConns = new();
+        // Per-room lock: all mutation of a room's state (commands + ticks) is
+        // serialized so two connections' commands can never interleave (the
+        // single-threaded-per-room actor model — no PlanLock double-fire race).
+        private readonly ConcurrentDictionary<string, SemaphoreSlim> _roomLocks = new();
+        private int _tokenCounter;
+
+        private SemaphoreSlim LockFor(string roomId)
+            => _roomLocks.GetOrAdd(roomId, _ => new SemaphoreSlim(1, 1));
+
+        public MatchHub(LoadedCatalog catalog, string catalogJson, IRoomStore store, Func<long>? now = null)
+        {
+            _catalog = catalog;
+            _catalogJson = catalogJson;
+            _store = store;
+            _now = now ?? (() => DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+        }
+
+        public string CatalogHash => _catalog.Hash;
+        public int RoomCount => _rooms.Count;
+
+        public async System.Threading.Tasks.Task HandleAsync(Connection conn, string raw)
+        {
+            var msg = ClientMessageV2.Parse(raw);
+            if (msg == null) { await conn.Send(J(ServerMsg.Error("badMessage", "unparseable"))); return; }
+
+            switch (msg)
+            {
+                case PingV2Msg:
+                    await conn.Send(J(ServerMsg.Pong()));
+                    return;
+                case JoinV2 join:
+                    await HandleJoin(conn, join);
+                    return;
+            }
+
+            if (conn.RoomId == null || !_rooms.TryGetValue(conn.RoomId, out var room))
+            {
+                await conn.Send(J(ServerMsg.Error("notJoined", "join first")));
+                return;
+            }
+
+            // Serialize all state mutation for this room (single-threaded actor).
+            var gate = LockFor(conn.RoomId);
+            await gate.WaitAsync();
+            try
+            {
+                if (msg is BattleAckMsg)
+                {
+                    room.BattleAck(conn.PlayerId, _now());
+                    await ReactToTransitions(conn.RoomId, room);
+                    return;
+                }
+
+                var (outcome, cmdId) = ApplyCommand(room, conn.PlayerId, msg);
+                if (!outcome.Ok)
+                {
+                    await conn.Send(J(ServerMsg.CmdRejected(cmdId, outcome.Code, outcome.Message)));
+                    return;
+                }
+                if (conn.Seat is int seat)
+                    await conn.Send(J(ServerMsg.CmdAccepted(cmdId, room.SnapshotFor(seat))));
+                _store.Save(conn.RoomId, room);
+                await ReactToTransitions(conn.RoomId, room);
+            }
+            finally { gate.Release(); }
+        }
+
+        private async System.Threading.Tasks.Task HandleJoin(Connection conn, JoinV2 join)
+        {
+            if (conn.RoomId != null) { await conn.Send(J(ServerMsg.Error("alreadyJoined", "already joined"))); return; }
+            var room = _rooms.GetOrAdd(join.RoomId, id =>
+            {
+                var loaded = _store.TryLoad(id, _catalog, () => $"rt-{id}-{_tokenCounter++}");
+                var r = loaded ?? new MatchRoom(id, _catalog, _ => $"rt-{id}-{_tokenCounter++}");
+                _lastPhase[id] = r.CurrentPhase.ToString();
+                _seatConns[id] = new Connection?[2];
+                return r;
+            });
+
+            var gate = LockFor(join.RoomId);
+            await gate.WaitAsync();
+            try
+            {
+                var seated = room.Join(conn.PlayerId, join.PlayerName, _now(), join.ResumeToken);
+                if (seated == null) { await conn.Send(J(ServerMsg.Error("roomFull", "room is full"))); return; }
+
+                conn.RoomId = join.RoomId;
+                conn.Seat = seated.Value.seat;
+                _seatConns[join.RoomId][seated.Value.seat] = conn;
+
+                await conn.Send(J(ServerMsg.Welcome(
+                    seated.Value.seat, seated.Value.resumeToken, _catalogJson, _catalog.Hash,
+                    room.MatchConfig(), room.SnapshotFor(seated.Value.seat))));
+                _store.Save(join.RoomId, room);
+                await ReactToTransitions(join.RoomId, room);
+            }
+            finally { gate.Release(); }
+        }
+
+        /// <summary>Drive every room's phase machine (called by the host ticker).</summary>
+        public async System.Threading.Tasks.Task TickAll()
+        {
+            long t = _now();
+            foreach (var (roomId, room) in _rooms.Select(kv => (kv.Key, kv.Value)).ToList())
+            {
+                var gate = LockFor(roomId);
+                await gate.WaitAsync();
+                try
+                {
+                    if (room.Tick(t))
+                    {
+                        _store.Save(roomId, room);
+                        await ReactToTransitions(roomId, room);
+                    }
+                }
+                finally { gate.Release(); }
+            }
+        }
+
+        private async System.Threading.Tasks.Task ReactToTransitions(string roomId, MatchRoom room)
+        {
+            var phase = room.CurrentPhase.ToString();
+            if (_lastPhase.TryGetValue(roomId, out var prev) && prev == phase) return;
+            _lastPhase[roomId] = phase;
+
+            if (room.CurrentPhase == Phase.Battle)
+            {
+                var armies = room.RevealArmies().Select(a => (object)new { seat = a.seat, cards = a.cards });
+                await Broadcast(roomId, ServerMsg.RevealSnapshot(room.CurrentRound, armies));
+                await Broadcast(roomId, ServerMsg.BattleStarted(room.CurrentRound, _now(), room.LastBattleLog != null));
+                if (room.LastBattleLog != null)
+                    await Broadcast(roomId, ServerMsg.BattleLog(room.LastBattleRound, room.LastBattleLog));
+            }
+            else if (room.CurrentPhase == Phase.Results)
+            {
+                var r = room.LastRoundResult();
+                if (r != null)
+                {
+                    var hpDamage = r.HpDamage.Select(d => (object)new { seat = d.seat, amount = d.amount });
+                    var hp = r.Hp.Select(h => (object)new { seat = h.seat, hp = h.hp });
+                    await Broadcast(roomId, ServerMsg.RoundResult(r.Round, r.WinnerSeat, hpDamage, hp,
+                        r.WinnerSeat == null ? "draw" : $"seat {r.WinnerSeat} wins"));
+                }
+            }
+            else if (room.CurrentPhase == Phase.MatchEnded)
+            {
+                var finalHp = room.FinalHp().Select(h => (object)new { seat = h.seat, hp = h.hp });
+                await Broadcast(roomId, ServerMsg.MatchEnded(room.Winner, finalHp));
+            }
+            await BroadcastPhase(roomId, room);
+        }
+
+        private async System.Threading.Tasks.Task BroadcastPhase(string roomId, MatchRoom room)
+        {
+            for (int seat = 0; seat < 2; seat++)
+            {
+                var conn = _seatConns[roomId][seat];
+                if (conn != null) await conn.Send(J(ServerMsg.Phase(room.SnapshotFor(seat))));
+            }
+        }
+
+        private async System.Threading.Tasks.Task Broadcast(string roomId, object message)
+        {
+            var text = J(message);
+            foreach (var conn in _seatConns[roomId])
+                if (conn != null) await conn.Send(text);
+        }
+
+        public void Disconnect(Connection conn)
+        {
+            if (conn.RoomId == null) return;
+            if (_rooms.TryGetValue(conn.RoomId, out var room))
+            {
+                room.Disconnect(conn.PlayerId);
+                if (conn.Seat is int seat && _seatConns.TryGetValue(conn.RoomId, out var conns))
+                    conns[seat] = null;
+                if (room.IsEmpty)
+                {
+                    _rooms.TryRemove(conn.RoomId, out _);
+                    _lastPhase.TryRemove(conn.RoomId, out _);
+                    _seatConns.TryRemove(conn.RoomId, out _);
+                }
+            }
+        }
+
+        private static (CommandOutcome, string cmdId) ApplyCommand(MatchRoom room, string playerId, ClientMessageV2 msg)
+        {
+            long now = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds();
+            return msg switch
+            {
+                PickCommanderMsg m => (room.PickCommander(playerId, m.CommanderId, now), m.CmdId),
+                BuySquadMsg m => (room.BuySquad(playerId, m.UnitId, m.Anchor.Row, m.Anchor.Col, m.Orientation), m.CmdId),
+                MoveSquadMsg m => (room.MoveSquad(playerId, m.CardId, m.Anchor.Row, m.Anchor.Col, m.Orientation), m.CmdId),
+                SellSquadMsg m => (room.SellSquad(playerId, m.CardId), m.CmdId),
+                UnlockUnitMsg m => (room.UnlockUnit(playerId, m.UnitId), m.CmdId),
+                BuyTechMsg m => (room.BuyTech(playerId, m.UnitId, m.TechId), m.CmdId),
+                BuyLevelMsg m => (room.BuyLevel(playerId, m.CardId), m.CmdId),
+                SetReadyMsg m => (room.SetReady(playerId, m.Ready, now), m.CmdId),
+                _ => (CommandOutcome.Fail("badMessage", "not a command"), ""),
+            };
+        }
+
+        private static string J(object o) => Newtonsoft.Json.JsonConvert.SerializeObject(o);
+    }
+}

--- a/dotnet/BoardGame.BattleServer/Program.cs
+++ b/dotnet/BoardGame.BattleServer/Program.cs
@@ -1,19 +1,63 @@
-// Production battle server host. M0: a bare /health liveness probe so the
-// solution builds and the deploy path exists end-to-end. WebSocket rooms, the
-// match loop, the sim burst, and SQLite persistence are wired in at M5.
+// Production battle server (M5): ASP.NET Core WebSocket host driving the ported
+// C# MatchRoom. /health probe, /ws protocol-V2 endpoint, a background deadline
+// ticker, and SQLite persistence (BOARDGAME_DB path; falls back to in-memory).
+// At plan-lock the MatchRoom runs the Core sim and this host ships battleStarted
+// + battleLog + roundResult.
+using BoardGame.BattleServer;
 using BoardGame.Core;
 
 var builder = WebApplication.CreateBuilder(args);
-var app = builder.Build();
 
-app.MapGet("/health", () => Results.Json(new
-{
-    status = "ok",
-    schemaVersion = EngineInfo.SchemaVersion,
-}));
+var (catalog, catalogJson) = CatalogSource.Load();
+
+IRoomStore store;
+var dbPath = Environment.GetEnvironmentVariable("BOARDGAME_DB");
+if (!string.IsNullOrEmpty(dbPath))
+    store = new SqliteRoomStore($"Data Source={dbPath}");
+else
+    store = new InMemoryRoomStore();
+
+var hub = new MatchHub(catalog, catalogJson, store);
+builder.Services.AddSingleton(hub);
+builder.Services.AddHostedService(sp => new TickerService(sp.GetRequiredService<MatchHub>()));
+
+var app = builder.Build();
+app.UseWebSockets();
+
+// Newtonsoft (not Results.Json/System.Text.Json) — matches the wire serializer
+// and avoids a PipeWriter API mismatch when a net8.0 app rolls forward onto a
+// newer runtime in the test host.
+app.MapGet("/health", () => Results.Content(
+    Newtonsoft.Json.JsonConvert.SerializeObject(new
+    {
+        status = "ok",
+        protocolVersion = BoardGame.Core.Match.ProtocolV2.Version,
+        schemaVersion = EngineInfo.SchemaVersion,
+        catalogHash = hub.CatalogHash,
+        rooms = hub.RoomCount,
+    }),
+    "application/json"));
+
+WebSocketEndpoint.Map(app, hub);
 
 app.Run();
 
-// Exposed so an M5 WebApplicationFactory-based integration test can boot the
-// same host in-process.
+// A hosted background service that advances every room's phase deadlines.
+sealed class TickerService : BackgroundService
+{
+    private readonly MatchHub _hub;
+    public TickerService(MatchHub hub) => _hub = hub;
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        using var timer = new PeriodicTimer(TimeSpan.FromMilliseconds(250));
+        while (await timer.WaitForNextTickAsync(stoppingToken))
+        {
+            try { await _hub.TickAll(); }
+            catch { /* never let a tick crash the loop */ }
+        }
+    }
+}
+
+// Exposed so a WebApplicationFactory-based integration test can boot the host.
 public partial class Program { }

--- a/dotnet/BoardGame.BattleServer/RoomStore.cs
+++ b/dotnet/BoardGame.BattleServer/RoomStore.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Concurrent;
+using BoardGame.Core.Catalog;
+using BoardGame.Core.Match;
+using Microsoft.Data.Sqlite;
+using Newtonsoft.Json;
+
+namespace BoardGame.BattleServer
+{
+    /// <summary>Persists room state at phase transitions so a restart resumes.</summary>
+    public interface IRoomStore
+    {
+        void Save(string roomId, MatchRoom room);
+        MatchRoom? TryLoad(string roomId, LoadedCatalog catalog, Func<string> tokenGen);
+    }
+
+    /// <summary>In-memory store for tests (still exercises capture/restore).</summary>
+    public sealed class InMemoryRoomStore : IRoomStore
+    {
+        private readonly ConcurrentDictionary<string, string> _rows = new();
+
+        public void Save(string roomId, MatchRoom room)
+            => _rows[roomId] = JsonConvert.SerializeObject(room.CaptureState());
+
+        public MatchRoom? TryLoad(string roomId, LoadedCatalog catalog, Func<string> tokenGen)
+        {
+            if (!_rows.TryGetValue(roomId, out var json)) return null;
+            return Rehydrate(json, catalog, tokenGen);
+        }
+
+        internal static MatchRoom? Rehydrate(string json, LoadedCatalog catalog, Func<string> tokenGen)
+        {
+            var snap = JsonConvert.DeserializeObject<MatchRoomSnapshot>(json);
+            if (snap == null) return null;
+            var room = new MatchRoom(snap.Id, catalog, _ => tokenGen());
+            room.RestoreState(snap);
+            return room;
+        }
+    }
+
+    /// <summary>
+    /// SQLite-backed store: one row per room (the full snapshot as JSON), upserted
+    /// at every phase transition / accepted command — restart-safe. A separate
+    /// archive table records finished matches.
+    /// </summary>
+    public sealed class SqliteRoomStore : IRoomStore, IDisposable
+    {
+        private readonly SqliteConnection _conn;
+        private readonly object _lock = new();
+
+        public SqliteRoomStore(string connectionString)
+        {
+            _conn = new SqliteConnection(connectionString);
+            _conn.Open();
+            Exec("CREATE TABLE IF NOT EXISTS rooms (roomId TEXT PRIMARY KEY, snapshot TEXT NOT NULL, updatedAt INTEGER NOT NULL);");
+            Exec("CREATE TABLE IF NOT EXISTS matches (roomId TEXT, snapshot TEXT NOT NULL, endedAt INTEGER NOT NULL);");
+        }
+
+        public void Save(string roomId, MatchRoom room)
+        {
+            var json = JsonConvert.SerializeObject(room.CaptureState());
+            lock (_lock)
+            {
+                using var cmd = _conn.CreateCommand();
+                cmd.CommandText = "INSERT INTO rooms(roomId, snapshot, updatedAt) VALUES ($id, $snap, $ts) " +
+                                  "ON CONFLICT(roomId) DO UPDATE SET snapshot=$snap, updatedAt=$ts;";
+                cmd.Parameters.AddWithValue("$id", roomId);
+                cmd.Parameters.AddWithValue("$snap", json);
+                cmd.Parameters.AddWithValue("$ts", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                cmd.ExecuteNonQuery();
+
+                if (room.CurrentPhase == Phase.MatchEnded)
+                {
+                    using var arch = _conn.CreateCommand();
+                    arch.CommandText = "INSERT INTO matches(roomId, snapshot, endedAt) VALUES ($id, $snap, $ts);";
+                    arch.Parameters.AddWithValue("$id", roomId);
+                    arch.Parameters.AddWithValue("$snap", json);
+                    arch.Parameters.AddWithValue("$ts", DateTimeOffset.UtcNow.ToUnixTimeMilliseconds());
+                    arch.ExecuteNonQuery();
+                }
+            }
+        }
+
+        public MatchRoom? TryLoad(string roomId, LoadedCatalog catalog, Func<string> tokenGen)
+        {
+            lock (_lock)
+            {
+                using var cmd = _conn.CreateCommand();
+                cmd.CommandText = "SELECT snapshot FROM rooms WHERE roomId = $id;";
+                cmd.Parameters.AddWithValue("$id", roomId);
+                var json = cmd.ExecuteScalar() as string;
+                if (json == null) return null;
+                return InMemoryRoomStore.Rehydrate(json, catalog, tokenGen);
+            }
+        }
+
+        private void Exec(string sql)
+        {
+            using var cmd = _conn.CreateCommand();
+            cmd.CommandText = sql;
+            cmd.ExecuteNonQuery();
+        }
+
+        public void Dispose() => _conn.Dispose();
+    }
+}

--- a/dotnet/BoardGame.BattleServer/WebSocketEndpoint.cs
+++ b/dotnet/BoardGame.BattleServer/WebSocketEndpoint.cs
@@ -1,0 +1,67 @@
+using System.Net.WebSockets;
+using System.Text;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+
+namespace BoardGame.BattleServer
+{
+    /// <summary>
+    /// The /ws protocol-V2 endpoint, shared by Program (production) and the
+    /// integration tests (a real Kestrel host on an ephemeral port), so both
+    /// exercise identical wiring.
+    /// </summary>
+    public static class WebSocketEndpoint
+    {
+        public static void Map(WebApplication app, MatchHub hub)
+        {
+            app.Map("/ws", async context =>
+            {
+                if (!context.WebSockets.IsWebSocketRequest)
+                {
+                    context.Response.StatusCode = 400;
+                    return;
+                }
+                using var ws = await context.WebSockets.AcceptWebSocketAsync();
+                var sendLock = new SemaphoreSlim(1, 1);
+                var conn = new Connection(async text =>
+                {
+                    var bytes = Encoding.UTF8.GetBytes(text);
+                    await sendLock.WaitAsync();
+                    try
+                    {
+                        if (ws.State == WebSocketState.Open)
+                            await ws.SendAsync(bytes, WebSocketMessageType.Text, true, CancellationToken.None);
+                    }
+                    finally { sendLock.Release(); }
+                });
+
+                var buffer = new byte[16 * 1024];
+                try
+                {
+                    while (ws.State == WebSocketState.Open)
+                    {
+                        using var ms = new MemoryStream();
+                        WebSocketReceiveResult result;
+                        do
+                        {
+                            result = await ws.ReceiveAsync(buffer, CancellationToken.None);
+                            if (result.MessageType == WebSocketMessageType.Close)
+                            {
+                                await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "", CancellationToken.None);
+                                break;
+                            }
+                            ms.Write(buffer, 0, result.Count);
+                        } while (!result.EndOfMessage);
+
+                        if (result.MessageType == WebSocketMessageType.Close) break;
+                        var raw = Encoding.UTF8.GetString(ms.ToArray());
+                        if (raw.Length == 0) continue;
+                        await hub.HandleAsync(conn, raw);
+                    }
+                }
+                catch (WebSocketException) { /* client dropped */ }
+                finally { hub.Disconnect(conn); }
+            });
+        }
+    }
+}

--- a/dotnet/BoardGame.Core.Tests/MatchRoomTests.cs
+++ b/dotnet/BoardGame.Core.Tests/MatchRoomTests.cs
@@ -1,0 +1,187 @@
+using System.Linq;
+using BoardGame.Core.Catalog;
+using BoardGame.Core.Match;
+using Xunit;
+
+namespace BoardGame.Core.Tests
+{
+    /// <summary>
+    /// C# port of apps/game-server/src/matchRoom.test.ts — confirms the ported
+    /// reducer behaves identically to the Bun spec (the M5 conformance suite),
+    /// now with REAL simulated battles at plan-lock.
+    /// </summary>
+    public class MatchRoomTests
+    {
+        private static LoadedCatalog Catalog() => CatalogLoader.Load(CatalogTestData.CanonicalJson());
+
+        private static MatchRoom NewRoom(string id = "m")
+            => new MatchRoom(id, Catalog(), seat => $"tok-{id}-{seat}");
+
+        private static void StartMatch(MatchRoom room, long now = 0)
+        {
+            room.Join("p0", "Alice", now);
+            room.Join("p1", "Bob", now);
+            Assert.Equal(Phase.CommanderPick, room.CurrentPhase);
+            var off0 = room.SnapshotFor(0).CommanderOffers[0];
+            var off1 = room.SnapshotFor(1).CommanderOffers[0];
+            Assert.True(room.PickCommander("p0", off0, now).Ok);
+            Assert.True(room.PickCommander("p1", off1, now).Ok);
+            Assert.Equal(Phase.Planning, room.CurrentPhase);
+            Assert.Equal(1, room.CurrentRound);
+        }
+
+        [Fact]
+        public void StaysInLobbyUntilBothConnect()
+        {
+            var room = NewRoom();
+            room.Join("p0", "Alice", 0);
+            Assert.Equal(Phase.Lobby, room.CurrentPhase);
+            room.Join("p1", "Bob", 0);
+            Assert.Equal(Phase.CommanderPick, room.CurrentPhase);
+        }
+
+        [Fact]
+        public void RejectsUnofferedCommander()
+        {
+            var room = NewRoom();
+            room.Join("p0", "Alice", 0);
+            room.Join("p1", "Bob", 0);
+            var r = room.PickCommander("p0", "notReal", 0);
+            Assert.False(r.Ok);
+            Assert.Equal("unknownCommander", r.Code);
+        }
+
+        [Fact]
+        public void ThirdPlayerCannotJoin()
+        {
+            var room = NewRoom();
+            room.Join("p0", "Alice", 0);
+            room.Join("p1", "Bob", 0);
+            Assert.Null(room.Join("p2", "Carol", 0));
+        }
+
+        [Fact]
+        public void StartingArmyAndIncomeMaterialize()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            var own = room.SnapshotFor(0).Own;
+            Assert.True(own.Cards.Count >= 2);
+            Assert.Contains(own.Cards, c => c.UnitId == "cathedral");
+            Assert.True(own.Coin >= 200);
+        }
+
+        [Fact]
+        public void BuySquadSpendsAndPlaces()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            var before = room.SnapshotFor(0).Own;
+            var r = room.BuySquad("p0", "footman", 0, 10, "north");
+            Assert.True(r.Ok, r.Message);
+            var after = room.SnapshotFor(0).Own;
+            Assert.Equal(before.Coin - 100, after.Coin);
+            Assert.Equal(before.DeploysRemaining - 1, after.DeploysRemaining);
+            Assert.Contains(after.Cards, c => c.UnitId == "footman");
+        }
+
+        [Fact]
+        public void RejectsPlacementOutsideOwnHalf()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            var r = room.BuySquad("p0", "footman", 2, 40, "north");
+            Assert.False(r.Ok);
+            Assert.Equal("outsideOwnHalf", r.Code);
+        }
+
+        [Fact]
+        public void UnlockGatesLockedUnits()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            Assert.Equal("notUnlocked", room.BuySquad("p0", "ballista", 0, 10, "north").Code);
+            Assert.True(room.UnlockUnit("p0", "ballista").Ok);
+            var r = room.BuySquad("p0", "ballista", 0, 10, "north");
+            Assert.True(r.Ok || r.Code == "insufficientFunds");
+        }
+
+        [Fact]
+        public void HiddenPlanningDoesNotLeakTheOpponentPlan()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            room.BuySquad("p0", "footman", 0, 10, "north");
+            var oppView = room.SnapshotFor(1).Opponent!;
+            Assert.DoesNotContain(oppView.Cards, c => c.UnitId == "footman");
+        }
+
+        [Fact]
+        public void BothReadyLocksPlanAndRunsARealBattle()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            room.BuySquad("p0", "footman", 0, 10, "north");
+            room.BuySquad("p1", "archer", 0, 30, "north");
+            room.SetReady("p0", true, 0);
+            room.SetReady("p1", true, 0);
+            Assert.Equal(Phase.Battle, room.CurrentPhase);
+            // M5: a real battle log exists (the cutover's only visible change).
+            Assert.NotNull(room.LastBattleLog);
+        }
+
+        [Fact]
+        public void FullMatchReachesHpZero()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            int placed = 0;
+            int guard = 0;
+            while (room.CurrentPhase != Phase.MatchEnded && guard < 300)
+            {
+                guard++;
+                if (room.CurrentPhase == Phase.Planning)
+                {
+                    room.UnlockUnit("p0", "ballista");
+                    for (int d = 0; d < 3; d++)
+                    {
+                        int row = (placed % 10) * 3;
+                        int col = 6 + placed / 10 * 5;
+                        if (room.BuySquad("p0", "ballista", row, col, "north").Ok) placed++;
+                    }
+                    room.SetReady("p0", true, 0);
+                    room.SetReady("p1", true, 0);
+                }
+                else if (room.CurrentPhase == Phase.Battle)
+                {
+                    room.BattleAck("p0", 0);
+                    room.BattleAck("p1", 0);
+                }
+                else if (room.CurrentPhase == Phase.Results)
+                {
+                    room.Tick(1_000_000);
+                }
+            }
+            Assert.Equal(Phase.MatchEnded, room.CurrentPhase);
+            Assert.Equal(0, room.Winner);
+            Assert.Equal(0, room.FinalHp().First(h => h.seat == 1).hp);
+        }
+
+        [Fact]
+        public void ReconnectRestoresSeatState()
+        {
+            var room = NewRoom();
+            StartMatch(room);
+            room.BuySquad("p0", "footman", 0, 10, "north");
+            var token = "tok-m-0";
+            Assert.Equal(0, room.SeatByResumeToken(token));
+            room.Disconnect("p0");
+            Assert.False(room.SnapshotFor(0).Own.Connected);
+            var rejoin = room.Join("p0b", "Alice", 0, token);
+            Assert.NotNull(rejoin);
+            Assert.Equal(0, rejoin!.Value.seat);
+            Assert.True(room.SnapshotFor(0).Own.Connected);
+            Assert.Contains(room.SnapshotFor(0).Own.Cards, c => c.UnitId == "footman");
+        }
+    }
+}

--- a/dotnet/BoardGame.Core/Runtime/Match/MatchRoom.cs
+++ b/dotnet/BoardGame.Core/Runtime/Match/MatchRoom.cs
@@ -1,0 +1,801 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using BoardGame.Core.Catalog;
+using BoardGame.Core.Generated;
+
+namespace BoardGame.Core.Match
+{
+    public enum Phase { Lobby, CommanderPick, Planning, Battle, Results, MatchEnded }
+
+    public readonly struct CommandOutcome
+    {
+        public readonly bool Ok;
+        public readonly string Code;
+        public readonly string Message;
+        private CommandOutcome(bool ok, string code, string message) { Ok = ok; Code = code; Message = message; }
+        public static readonly CommandOutcome Success = new CommandOutcome(true, "", "");
+        public static CommandOutcome Fail(string code, string message) => new CommandOutcome(false, code, message);
+    }
+
+    /// <summary>
+    /// C# port of apps/game-server/src/matchRoom.ts — the pure, clock-injected
+    /// match reducer. Structurally identical to the TS spec so the ported test
+    /// suite confirms equivalence. At plan-lock the BattleServer runs the Core
+    /// sim and ships a real battleLog (the only behavioral difference from the
+    /// Bun stub). No wall-clock or RNG here — deterministic and restart-safe.
+    /// </summary>
+    public sealed class MatchRoom
+    {
+        public const double SurvivorFactor = 0.5;
+        public const int MinRoundDamage = 100;
+
+        private static readonly int[] Seats = { 0, 1 };
+
+        public string Id { get; }
+        private readonly LoadedCatalog _catalog;
+        private readonly MatchRules _rules;
+
+        public Phase CurrentPhase { get; private set; } = Phase.Lobby;
+        public int CurrentRound { get; private set; }
+        public long PhaseDeadline { get; private set; }
+        public int? Winner { get; private set; }
+
+        private int _nextCardId = 1;
+        private readonly SeatState[] _seats;
+        private PendingBattle? _pending;
+        private RoundResultData? _lastResult;
+
+        public MatchRoom(string id, LoadedCatalog catalog, Func<int, string> tokenGen)
+        {
+            Id = id;
+            _catalog = catalog;
+            _rules = catalog.MatchRules;
+            _seats = Seats.Select(seat => new SeatState { Seat = seat, ResumeToken = tokenGen(seat) }).ToArray();
+        }
+
+        public bool IsEmpty => _seats.All(s => !s.Connected);
+        private bool BothConnected => _seats.All(s => s.Connected);
+
+        // -------------------------------------------------------------------
+        // Persistence: capture / restore the full reconstructable state so a
+        // server restart resumes the match (design doc §8). Connection-only
+        // fields (PlayerId/Connected) are NOT persisted — players reconnect via
+        // their resumeToken. Mid-battle: on restore the phase is preserved; the
+        // battle log is recomputed deterministically at the next plan-lock if
+        // needed (seed is round-derived).
+        // -------------------------------------------------------------------
+
+        public MatchRoomSnapshot CaptureState() => new MatchRoomSnapshot
+        {
+            Id = Id,
+            Phase = PhaseToString(CurrentPhase),
+            Round = CurrentRound,
+            PhaseDeadline = PhaseDeadline,
+            NextCardId = _nextCardId,
+            Winner = Winner,
+            Seats = _seats.Select(s => new MatchRoomSnapshot.SeatSnapshot
+            {
+                Seat = s.Seat,
+                PlayerName = s.PlayerName,
+                ResumeToken = s.ResumeToken,
+                CommanderId = s.CommanderId,
+                CommanderOffers = s.CommanderOffers.ToList(),
+                Hp = s.Hp,
+                Coin = s.Coin,
+                DeploysRemaining = s.DeploysRemaining,
+                UnlocksRemaining = s.UnlocksRemaining,
+                Ready = s.Ready,
+                Cards = s.Cards.Select(CloneCard).ToList(),
+                RevealedCards = s.RevealedCards.Select(CloneCard).ToList(),
+                UnlockedUnits = s.UnlockedUnits.ToList(),
+                PurchasedTechs = s.PurchasedTechs.ToList(),
+                TechPriceByUnit = new Dictionary<string, int>(s.TechPriceByUnit),
+            }).ToList(),
+        };
+
+        public void RestoreState(MatchRoomSnapshot snap)
+        {
+            CurrentPhase = ParsePhase(snap.Phase);
+            CurrentRound = snap.Round;
+            PhaseDeadline = snap.PhaseDeadline;
+            _nextCardId = snap.NextCardId;
+            Winner = snap.Winner;
+            foreach (var ss in snap.Seats)
+            {
+                var s = _seats[ss.Seat];
+                s.PlayerName = ss.PlayerName;
+                s.ResumeToken = ss.ResumeToken;
+                s.CommanderId = ss.CommanderId;
+                s.CommanderOffers = ss.CommanderOffers.ToList();
+                s.Hp = ss.Hp;
+                s.Coin = ss.Coin;
+                s.DeploysRemaining = ss.DeploysRemaining;
+                s.UnlocksRemaining = ss.UnlocksRemaining;
+                s.Ready = ss.Ready;
+                s.Cards = ss.Cards.Select(CloneCard).ToList();
+                s.RevealedCards = ss.RevealedCards.Select(CloneCard).ToList();
+                s.UnlockedUnits = new HashSet<string>(ss.UnlockedUnits);
+                s.PurchasedTechs = new HashSet<string>(ss.PurchasedTechs);
+                s.TechPriceByUnit = new Dictionary<string, int>(ss.TechPriceByUnit);
+                s.PlayerId = null;
+                s.Connected = false;
+            }
+        }
+
+        private static Phase ParsePhase(string p) => p switch
+        {
+            "commanderPick" => Phase.CommanderPick,
+            "planning" => Phase.Planning,
+            "battle" => Phase.Battle,
+            "results" => Phase.Results,
+            "matchEnded" => Phase.MatchEnded,
+            _ => Phase.Lobby,
+        };
+
+        // -------------------------------------------------------------------
+        // Membership
+        // -------------------------------------------------------------------
+
+        public int? SeatByResumeToken(string token)
+        {
+            var s = _seats.FirstOrDefault(x => x.ResumeToken == token);
+            return s?.Seat;
+        }
+
+        public (int seat, string resumeToken)? Join(string playerId, string playerName, long now, string? resumeToken = null)
+        {
+            if (resumeToken != null)
+            {
+                var seatNo = SeatByResumeToken(resumeToken);
+                if (seatNo != null)
+                {
+                    var s = _seats[seatNo.Value];
+                    s.PlayerId = playerId;
+                    if (!string.IsNullOrEmpty(playerName)) s.PlayerName = playerName;
+                    s.Connected = true;
+                    return (s.Seat, s.ResumeToken);
+                }
+            }
+            var free = _seats.FirstOrDefault(x => !x.Connected && x.PlayerId == null);
+            if (free == null) return null;
+            free.PlayerId = playerId;
+            free.PlayerName = playerName;
+            free.Connected = true;
+            MaybeStartCommanderPick(now);
+            return (free.Seat, free.ResumeToken);
+        }
+
+        public void Disconnect(string playerId)
+        {
+            var s = _seats.FirstOrDefault(x => x.PlayerId == playerId);
+            if (s != null) s.Connected = false;
+        }
+
+        public int? SeatOfPlayer(string playerId)
+        {
+            var s = _seats.FirstOrDefault(x => x.PlayerId == playerId);
+            return s?.Seat;
+        }
+
+        // -------------------------------------------------------------------
+        // Phase transitions
+        // -------------------------------------------------------------------
+
+        private void MaybeStartCommanderPick(long now)
+        {
+            if (CurrentPhase != Phase.Lobby || !BothConnected) return;
+            CurrentPhase = Phase.CommanderPick;
+            int offered = _rules.CommandersOffered;
+            var all = _rules.Commanders.Select(c => c.Id).ToList();
+            foreach (var s in _seats)
+            {
+                s.CommanderOffers = Rotate(all, s.Seat).Take(offered).ToList();
+                s.CommanderId = null;
+            }
+            PhaseDeadline = now + (long)_rules.Timers.CommanderPickSeconds * 1000;
+        }
+
+        /// <summary>Advance deadlines. Returns true if a transition occurred.</summary>
+        public bool Tick(long now)
+        {
+            if (PhaseDeadline != 0 && now < PhaseDeadline) return false;
+            switch (CurrentPhase)
+            {
+                case Phase.CommanderPick:
+                    foreach (var s in _seats)
+                        if (s.CommanderId == null) s.CommanderId = s.CommanderOffers.FirstOrDefault();
+                    BeginPlanning(1, now);
+                    return true;
+                case Phase.Planning:
+                    PlanLock(now);
+                    return true;
+                case Phase.Battle:
+                    ResolveBattle(now);
+                    return true;
+                case Phase.Results:
+                    AfterResults(now);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        private bool AllCommandersPicked() => _seats.All(s => s.CommanderId != null);
+
+        private void BeginPlanning(int round, long now)
+        {
+            CurrentPhase = Phase.Planning;
+            CurrentRound = round;
+            foreach (var s in _seats)
+            {
+                if (round == 1) MaterializeStartingArmy(s);
+                s.Coin += IncomeForSeat(s, round);
+                s.DeploysRemaining = DeploysForSeat(s);
+                s.UnlocksRemaining = UnlocksForSeat(s);
+                s.Ready = false;
+            }
+            PhaseDeadline = now + (long)_rules.Timers.DeploySeconds * 1000;
+        }
+
+        private void PlanLock(long now)
+        {
+            foreach (var s in _seats) s.RevealedCards = s.Cards.Select(CloneCard).ToList();
+            _pending = new PendingBattle
+            {
+                Armies = _seats.Select(s => (s.Seat, s.RevealedCards.Select(CloneCard).ToList())).ToList(),
+                Acked = new HashSet<int>(),
+            };
+            CurrentPhase = Phase.Battle;
+            PhaseDeadline = now + (long)_rules.Timers.BattleSeconds * 1000;
+            RunBattle();
+        }
+
+        public void BattleAck(string playerId, long now)
+        {
+            if (CurrentPhase != Phase.Battle || _pending == null) return;
+            var seat = SeatOfPlayer(playerId);
+            if (seat == null) return;
+            _pending.Acked.Add(seat.Value);
+            if (_pending.Acked.Count == Seats.Length) ResolveBattle(now);
+        }
+
+        /// <summary>The battle event log from the last plan-lock (M5: real sim).</summary>
+        public object? LastBattleLog { get; private set; }
+        public int LastBattleRound { get; private set; }
+
+        private void RunBattle()
+        {
+            // Run the Core sim on the revealed armies and keep its event log +
+            // survivor values. This is the one behavioral change from the Bun stub.
+            if (_pending == null) return;
+            var sink = new Events.ListEventSink();
+            var simA = ToArmy(0);
+            var simB = ToArmy(1);
+            var result = new Sim.BattleSim(_catalog, (uint)(1000 + CurrentRound), sink).Run(simA, simB);
+            _pending.SimResult = result;
+            LastBattleLog = sink.Events;
+            LastBattleRound = CurrentRound;
+        }
+
+        private Sim.ArmyBlueprint ToArmy(int seat)
+        {
+            var army = new Sim.ArmyBlueprint { Seat = seat };
+            var s = _seats[seat];
+            foreach (var c in s.RevealedCards)
+            {
+                if (!_catalog.HasUnit(c.UnitId)) continue;
+                army.Squads.Add(new Sim.SquadBlueprint
+                {
+                    UnitId = c.UnitId,
+                    AnchorRow = c.Anchor.Row,
+                    AnchorCol = c.Anchor.Col,
+                    Orientation = ParseOrientation(c.Orientation),
+                    Level = c.Level,
+                    Invested = c.Invested,
+                    CardId = c.CardId,
+                });
+            }
+            return army;
+        }
+
+        private void ResolveBattle(long now)
+        {
+            if (CurrentPhase != Phase.Battle) return;
+
+            // Prefer the real sim's prorated survivor values; fall back to invested
+            // value if the sim produced nothing (empty armies).
+            int a, b;
+            int? winnerSeat;
+            if (_pending?.SimResult != null)
+            {
+                var r = _pending.SimResult;
+                a = r.SurvivorValueBySeat.GetValueOrDefault(0);
+                b = r.SurvivorValueBySeat.GetValueOrDefault(1);
+                winnerSeat = r.WinnerSeat < 0 ? (int?)null : r.WinnerSeat;
+            }
+            else
+            {
+                a = _seats[0].RevealedCards.Sum(c => c.Invested);
+                b = _seats[1].RevealedCards.Sum(c => c.Invested);
+                winnerSeat = a == b ? (int?)null : (a > b ? 0 : 1);
+            }
+
+            int damage;
+            if (winnerSeat == null)
+            {
+                damage = (int)Math.Round(Math.Min(a, b) * SurvivorFactor);
+            }
+            else
+            {
+                // Survivor value the winner inflicts (already prorated by the sim).
+                int winnerValue = winnerSeat == 0 ? a : b;
+                damage = Math.Max(MinRoundDamage, winnerValue);
+            }
+
+            var hpDamage = new List<(int seat, int amount)>();
+            foreach (var s in _seats)
+            {
+                bool takes = winnerSeat == null || s.Seat != winnerSeat.Value;
+                int amount = takes ? damage : 0;
+                if (amount > 0) s.Hp = Math.Max(0, s.Hp - amount);
+                hpDamage.Add((s.Seat, amount));
+            }
+
+            _lastResult = new RoundResultData { Round = CurrentRound, WinnerSeat = winnerSeat, HpDamage = hpDamage };
+            _pending = null;
+            CurrentPhase = Phase.Results;
+            PhaseDeadline = now + (long)_rules.Timers.ResultsHoldSeconds * 1000;
+        }
+
+        private void AfterResults(long now)
+        {
+            if (CurrentPhase != Phase.Results) return;
+            var dead = _seats.Where(s => s.Hp <= 0).ToList();
+            if (dead.Count > 0)
+            {
+                var alive = _seats.Where(s => s.Hp > 0).ToList();
+                Winner = alive.Count == 1 ? alive[0].Seat : (int?)null;
+                CurrentPhase = Phase.MatchEnded;
+                PhaseDeadline = 0;
+                return;
+            }
+            BeginPlanning(CurrentRound + 1, now);
+        }
+
+        // -------------------------------------------------------------------
+        // Economy
+        // -------------------------------------------------------------------
+
+        private int IncomeForSeat(SeatState s, int round)
+        {
+            int income = _rules.Income.PerRoundIncrement * round;
+            if (round == 1) income += _rules.Income.StartingIncome;
+            income += CommanderEconomy(s).income;
+            return income;
+        }
+
+        private int DeploysForSeat(SeatState s) => _rules.DeploysPerRound + CommanderEconomy(s).deploy;
+        private int UnlocksForSeat(SeatState s) => _rules.UnlocksPerRound + CommanderEconomy(s).unlock;
+
+        private (int income, int deploy, int unlock, int startIncome) CommanderEconomy(SeatState s)
+        {
+            int income = 0, deploy = 0, unlock = 0, start = 0;
+            if (s.CommanderId == null) return (0, 0, 0, 0);
+            var cmd = _rules.Commanders.FirstOrDefault(c => c.Id == s.CommanderId);
+            if (cmd == null) return (0, 0, 0, 0);
+            foreach (var ability in cmd.Ability)
+            {
+                if (ability is CommanderEconomyMod e)
+                {
+                    income += e.IncomePerRoundAdd;
+                    deploy += e.DeploySlotsAdd;
+                    unlock += e.UnlockSlotsAdd;
+                    start += e.StartingIncomeAdd;
+                }
+            }
+            return (income, deploy, unlock, start);
+        }
+
+        private void MaterializeStartingArmy(SeatState s)
+        {
+            var cmd = _rules.Commanders.FirstOrDefault(c => c.Id == s.CommanderId);
+            s.Hp = cmd?.Hp ?? 5000;
+            s.Coin = CommanderEconomy(s).startIncome;
+            foreach (var b in _rules.StartingBuildings)
+            {
+                if (b.Seat != s.Seat) continue;
+                AddCard(s, b.UnitId, b.Anchor.Row, b.Anchor.Col, OrientationToString(b.Orientation), 0, free: true);
+            }
+            foreach (var su in cmd?.StartingUnits ?? new List<PlacedUnit>())
+                AddCard(s, su.UnitId, su.Anchor.Row, su.Anchor.Col, OrientationToString(su.Orientation), 0, free: true);
+        }
+
+        // -------------------------------------------------------------------
+        // Commands
+        // -------------------------------------------------------------------
+
+        public CommandOutcome PickCommander(string playerId, string commanderId, long now)
+        {
+            var s = RequireSeat(playerId);
+            if (s == null) return CommandOutcome.Fail("notJoined", "not in this room");
+            if (CurrentPhase != Phase.CommanderPick) return CommandOutcome.Fail("wrongPhase", "not in commander pick");
+            if (!s.CommanderOffers.Contains(commanderId)) return CommandOutcome.Fail("unknownCommander", "not offered");
+            if (s.CommanderId != null) return CommandOutcome.Fail("commanderAlreadyPicked", "already picked");
+            s.CommanderId = commanderId;
+            if (AllCommandersPicked()) BeginPlanning(1, now);
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome BuySquad(string playerId, string unitId, int row, int col, string orientation)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            if (!_catalog.TryGetUnit(unitId, out var unit)) return CommandOutcome.Fail("unknownUnit", "no unit");
+            if (unit.Cost.UnlockCost > 0 && !s.UnlockedUnits.Contains(unitId)) return CommandOutcome.Fail("notUnlocked", "not unlocked");
+            if (s.DeploysRemaining <= 0) return CommandOutcome.Fail("noDeploysLeft", "no deploys");
+            if (s.Coin < unit.Cost.DeployCost) return CommandOutcome.Fail("insufficientFunds", "not enough coin");
+            var placement = ValidatePlacement(s, unit, row, col, null);
+            if (placement != null) return placement.Value;
+            s.Coin -= unit.Cost.DeployCost;
+            s.DeploysRemaining -= 1;
+            AddCard(s, unitId, row, col, orientation, unit.Cost.DeployCost, free: false);
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome MoveSquad(string playerId, string cardId, int row, int col, string orientation)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            var card = s.Cards.FirstOrDefault(c => c.CardId == cardId);
+            if (card == null) return CommandOutcome.Fail("unknownCard", "no card");
+            if (!_catalog.TryGetUnit(card.UnitId, out var unit)) return CommandOutcome.Fail("unknownUnit", "unit missing");
+            var placement = ValidatePlacement(s, unit, row, col, cardId);
+            if (placement != null) return placement.Value;
+            card.Anchor = new SquadCardData.AnchorData { Row = row, Col = col };
+            card.Orientation = orientation;
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome SellSquad(string playerId, string cardId)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            var card = s.Cards.FirstOrDefault(c => c.CardId == cardId);
+            if (card == null) return CommandOutcome.Fail("unknownCard", "no card");
+            if (card.PurchasedRound != CurrentRound) return CommandOutcome.Fail("notThisRoundPurchase", "not this round");
+            s.Cards.Remove(card);
+            s.Coin += card.Invested;
+            s.DeploysRemaining += 1;
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome UnlockUnit(string playerId, string unitId)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            if (!_catalog.TryGetUnit(unitId, out var unit)) return CommandOutcome.Fail("unknownUnit", "no unit");
+            if (s.UnlockedUnits.Contains(unitId)) return CommandOutcome.Fail("alreadyUnlocked", "already unlocked");
+            if (s.UnlocksRemaining <= 0) return CommandOutcome.Fail("noUnlocksLeft", "no unlocks");
+            if (s.Coin < unit.Cost.UnlockCost) return CommandOutcome.Fail("insufficientFunds", "not enough coin");
+            s.Coin -= unit.Cost.UnlockCost;
+            s.UnlocksRemaining -= 1;
+            s.UnlockedUnits.Add(unitId);
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome BuyTech(string playerId, string unitId, string techId)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            if (!_catalog.TryGetUnit(unitId, out var unit)) return CommandOutcome.Fail("unknownUnit", "no unit");
+            var tech = unit.Techs.FirstOrDefault(t => t.Id == techId);
+            if (tech == null) return CommandOutcome.Fail("unknownTech", "no tech");
+            if (s.PurchasedTechs.Contains(techId)) return CommandOutcome.Fail("techAlreadyOwned", "already owned");
+            int price = s.TechPriceByUnit.GetValueOrDefault(unitId, tech.Cost);
+            if (s.Coin < price) return CommandOutcome.Fail("insufficientFunds", "not enough coin");
+            s.Coin -= price;
+            s.PurchasedTechs.Add(techId);
+            s.TechPriceByUnit[unitId] = s.TechPriceByUnit.GetValueOrDefault(unitId, tech.Cost) + _rules.TechPriceEscalation;
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome BuyLevel(string playerId, string cardId)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            var card = s.Cards.FirstOrDefault(c => c.CardId == cardId);
+            if (card == null) return CommandOutcome.Fail("unknownCard", "no card");
+            if (!_catalog.TryGetUnit(card.UnitId, out var unit)) return CommandOutcome.Fail("unknownUnit", "unit missing");
+            if (card.Xp < unit.Squad.XpToLevel) return CommandOutcome.Fail("xpNotReady", "not enough xp");
+            int cost = (int)Math.Round(unit.Cost.DeployCost * _rules.Leveling.UpgradeCostFraction);
+            if (s.Coin < cost) return CommandOutcome.Fail("insufficientFunds", "not enough coin");
+            s.Coin -= cost;
+            card.Xp -= unit.Squad.XpToLevel;
+            card.Level += 1;
+            card.Invested += cost;
+            return CommandOutcome.Success;
+        }
+
+        public CommandOutcome SetReady(string playerId, bool ready, long now)
+        {
+            var s = RequirePlanningSeat(playerId, out var err);
+            if (s == null) return err;
+            s.Ready = ready;
+            if (_seats.All(x => x.Ready)) PlanLock(now);
+            return CommandOutcome.Success;
+        }
+
+        // -------------------------------------------------------------------
+        // Snapshots (DTOs)
+        // -------------------------------------------------------------------
+
+        public MatchConfigDto MatchConfig() => new MatchConfigDto
+        {
+            Board = new BoardWH { W = _rules.Board.W, H = _rules.Board.H },
+            DeploysPerRound = _rules.DeploysPerRound,
+            UnlocksPerRound = _rules.UnlocksPerRound,
+            IncomePerRoundIncrement = _rules.Income.PerRoundIncrement,
+            DeploySeconds = _rules.Timers.DeploySeconds,
+            BattleSeconds = _rules.Timers.BattleSeconds,
+            CommanderPickSeconds = _rules.Timers.CommanderPickSeconds,
+            CommandersOffered = _rules.CommandersOffered,
+        };
+
+        public MatchSnapshotDto SnapshotFor(int seat)
+        {
+            var own = _seats[seat];
+            var opp = _seats[seat == 0 ? 1 : 0];
+            return new MatchSnapshotDto
+            {
+                Phase = PhaseToString(CurrentPhase),
+                Round = CurrentRound,
+                PhaseDeadline = PhaseDeadline,
+                CommanderOffers = own.CommanderOffers,
+                Own = SeatViewDtoOf(own),
+                Opponent = (opp.Connected || opp.PlayerId != null) ? OpponentViewDtoOf(opp) : null,
+            };
+        }
+
+        public RoundResultData? LastRoundResult()
+        {
+            if (_lastResult == null) return null;
+            _lastResult.Hp = _seats.Select(s => (s.Seat, s.Hp)).ToList();
+            return _lastResult;
+        }
+
+        public List<(int seat, List<SquadCardDto> cards)> RevealArmies()
+            => _seats.Select(s => (s.Seat, s.RevealedCards.Select(ToDto).ToList())).ToList();
+
+        public List<(int seat, int hp)> FinalHp() => _seats.Select(s => (s.Seat, s.Hp)).ToList();
+
+        private SeatViewDto SeatViewDtoOf(SeatState s) => new SeatViewDto
+        {
+            Seat = s.Seat,
+            PlayerName = s.PlayerName,
+            Connected = s.Connected,
+            CommanderId = s.CommanderId,
+            Hp = s.Hp,
+            Coin = s.Coin,
+            DeploysRemaining = s.DeploysRemaining,
+            UnlocksRemaining = s.UnlocksRemaining,
+            Ready = s.Ready,
+            Cards = s.Cards.Select(ToDto).ToList(),
+            Tech = new SeatTechStateDto
+            {
+                UnlockedUnits = s.UnlockedUnits.ToList(),
+                PurchasedTechs = s.PurchasedTechs.ToList(),
+                TechPriceByUnit = new Dictionary<string, int>(s.TechPriceByUnit),
+            },
+        };
+
+        private OpponentViewDto OpponentViewDtoOf(SeatState s) => new OpponentViewDto
+        {
+            Seat = s.Seat,
+            PlayerName = s.PlayerName,
+            Connected = s.Connected,
+            CommanderId = s.CommanderId,
+            Hp = s.Hp,
+            Cards = s.RevealedCards.Select(ToDto).ToList(),
+        };
+
+        private static SquadCardDto ToDto(SquadCardData c) => new SquadCardDto
+        {
+            CardId = c.CardId,
+            UnitId = c.UnitId,
+            Anchor = new WireAnchor { Row = c.Anchor.Row, Col = c.Anchor.Col },
+            Orientation = c.Orientation,
+            Level = c.Level,
+            Xp = c.Xp,
+            PurchasedRound = c.PurchasedRound,
+            Invested = c.Invested,
+        };
+
+        // -------------------------------------------------------------------
+        // Internals
+        // -------------------------------------------------------------------
+
+        private SeatState? RequireSeat(string playerId) => _seats.FirstOrDefault(s => s.PlayerId == playerId);
+
+        private SeatState? RequirePlanningSeat(string playerId, out CommandOutcome err)
+        {
+            var s = RequireSeat(playerId);
+            if (s == null) { err = CommandOutcome.Fail("notJoined", "not in this room"); return null; }
+            if (CurrentPhase != Phase.Planning) { err = CommandOutcome.Fail("wrongPhase", "not in planning"); return null; }
+            err = CommandOutcome.Success;
+            return s;
+        }
+
+        private void AddCard(SeatState s, string unitId, int row, int col, string orientation, int invested, bool free)
+        {
+            s.Cards.Add(new SquadCardData
+            {
+                CardId = $"sq{_nextCardId++}",
+                UnitId = unitId,
+                Anchor = new SquadCardData.AnchorData { Row = row, Col = col },
+                Orientation = orientation,
+                Level = 1,
+                Xp = 0,
+                PurchasedRound = free ? 0 : CurrentRound,
+                Invested = invested,
+            });
+        }
+
+        private CommandOutcome? ValidatePlacement(SeatState s, UnitDef unit, int row, int col, string? ignoreCardId)
+        {
+            var board = _rules.Board;
+            if (!Footprints.FitsBoard(unit, row, col, board.W, board.H))
+                return CommandOutcome.Fail("outOfBounds", $"does not fit {board.W}x{board.H}");
+            var tiles = Footprints.Tiles(unit, row, col);
+            if (unit.Placement.Domain != Domain.Building && !WithinSeatZones(s.Seat, tiles))
+                return CommandOutcome.Fail("outsideOwnHalf", "outside your deploy zone");
+            foreach (var other in s.Cards)
+            {
+                if (other.CardId == ignoreCardId) continue;
+                if (!_catalog.TryGetUnit(other.UnitId, out var ou)) continue;
+                var ot = Footprints.Tiles(ou, other.Anchor.Row, other.Anchor.Col);
+                if (tiles.Overlaps(ot)) return CommandOutcome.Fail("tileOccupied", $"overlaps {other.CardId}");
+            }
+            return null;
+        }
+
+        private bool WithinSeatZones(int seat, TileRect tiles)
+        {
+            foreach (var zone in _rules.DeployZones)
+            {
+                if (zone.Seat != seat) continue;
+                var r = zone.Rect;
+                if (tiles.RowStart >= r.Row && tiles.RowEnd <= r.Row + r.W - 1 &&
+                    tiles.ColStart >= r.Col && tiles.ColEnd <= r.Col + r.H - 1)
+                    return true;
+            }
+            return false;
+        }
+
+        private static SquadCardData CloneCard(SquadCardData c) => new SquadCardData
+        {
+            CardId = c.CardId,
+            UnitId = c.UnitId,
+            Anchor = new SquadCardData.AnchorData { Row = c.Anchor.Row, Col = c.Anchor.Col },
+            Orientation = c.Orientation,
+            Level = c.Level,
+            Xp = c.Xp,
+            PurchasedRound = c.PurchasedRound,
+            Invested = c.Invested,
+        };
+
+        private static List<T> Rotate<T>(List<T> arr, int by)
+        {
+            if (arr.Count == 0) return arr;
+            int n = ((by % arr.Count) + arr.Count) % arr.Count;
+            return arr.Skip(n).Concat(arr.Take(n)).ToList();
+        }
+
+        private static Orientation ParseOrientation(string s) => s switch
+        {
+            "east" => Orientation.East,
+            "south" => Orientation.South,
+            "west" => Orientation.West,
+            _ => Orientation.North,
+        };
+
+        private static string OrientationToString(Orientation o) => o switch
+        {
+            Orientation.East => "east",
+            Orientation.South => "south",
+            Orientation.West => "west",
+            _ => "north",
+        };
+
+        private static string PhaseToString(Phase p) => p switch
+        {
+            Phase.CommanderPick => "commanderPick",
+            Phase.Planning => "planning",
+            Phase.Battle => "battle",
+            Phase.Results => "results",
+            Phase.MatchEnded => "matchEnded",
+            _ => "lobby",
+        };
+
+        // Internal mutable state (never serialized directly; DTOs above are).
+        private sealed class SeatState
+        {
+            public int Seat;
+            public string? PlayerId;
+            public string PlayerName = "";
+            public string ResumeToken = "";
+            public bool Connected;
+            public string? CommanderId;
+            public List<string> CommanderOffers = new List<string>();
+            public int Hp;
+            public int Coin;
+            public int DeploysRemaining;
+            public int UnlocksRemaining;
+            public bool Ready;
+            public List<SquadCardData> Cards = new List<SquadCardData>();
+            public HashSet<string> UnlockedUnits = new HashSet<string>();
+            public HashSet<string> PurchasedTechs = new HashSet<string>();
+            public Dictionary<string, int> TechPriceByUnit = new Dictionary<string, int>();
+            public List<SquadCardData> RevealedCards = new List<SquadCardData>();
+        }
+
+        private sealed class PendingBattle
+        {
+            public List<(int seat, List<SquadCardData> cards)> Armies = new List<(int, List<SquadCardData>)>();
+            public HashSet<int> Acked = new HashSet<int>();
+            public Sim.BattleResult? SimResult;
+        }
+
+        public sealed class RoundResultData
+        {
+            public int Round;
+            public int? WinnerSeat;
+            public List<(int seat, int amount)> HpDamage = new List<(int, int)>();
+            public List<(int seat, int hp)> Hp = new List<(int, int)>();
+        }
+
+        public sealed class SquadCardData
+        {
+            public string CardId = "";
+            public string UnitId = "";
+            public AnchorData Anchor = new AnchorData();
+            public string Orientation = "north";
+            public int Level = 1;
+            public double Xp;
+            public int PurchasedRound;
+            public int Invested;
+            public sealed class AnchorData { public int Row; public int Col; }
+        }
+    }
+
+    /// <summary>Serializable full state of a MatchRoom (for SQLite persistence).</summary>
+    public sealed class MatchRoomSnapshot
+    {
+        public string Id { get; set; } = "";
+        public string Phase { get; set; } = "lobby";
+        public int Round { get; set; }
+        public long PhaseDeadline { get; set; }
+        public int NextCardId { get; set; }
+        public int? Winner { get; set; }
+        public List<SeatSnapshot> Seats { get; set; } = new List<SeatSnapshot>();
+
+        public sealed class SeatSnapshot
+        {
+            public int Seat { get; set; }
+            public string PlayerName { get; set; } = "";
+            public string ResumeToken { get; set; } = "";
+            public string? CommanderId { get; set; }
+            public List<string> CommanderOffers { get; set; } = new List<string>();
+            public int Hp { get; set; }
+            public int Coin { get; set; }
+            public int DeploysRemaining { get; set; }
+            public int UnlocksRemaining { get; set; }
+            public bool Ready { get; set; }
+            public List<MatchRoom.SquadCardData> Cards { get; set; } = new List<MatchRoom.SquadCardData>();
+            public List<MatchRoom.SquadCardData> RevealedCards { get; set; } = new List<MatchRoom.SquadCardData>();
+            public List<string> UnlockedUnits { get; set; } = new List<string>();
+            public List<string> PurchasedTechs { get; set; } = new List<string>();
+            public Dictionary<string, int> TechPriceByUnit { get; set; } = new Dictionary<string, int>();
+        }
+    }
+}

--- a/dotnet/BoardGame.Core/Runtime/Match/ProtocolV2.cs
+++ b/dotnet/BoardGame.Core/Runtime/Match/ProtocolV2.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+// Hand-maintained C# mirror of core/types/src/protocol-v2.ts (the match-loop
+// wire contract). Kept in sync with the zod schema; the BattleServer conformance
+// tests exercise the real messages, so drift surfaces there.
+namespace BoardGame.Core.Match
+{
+    public static class ProtocolV2
+    {
+        public const int Version = 2;
+    }
+
+    // -----------------------------------------------------------------------
+    // Blueprint / state DTOs (member layout is a pure function of the catalog)
+    // -----------------------------------------------------------------------
+
+    public sealed class WireAnchor
+    {
+        [JsonProperty("row")] public int Row { get; set; }
+        [JsonProperty("col")] public int Col { get; set; }
+    }
+
+    public sealed class SquadCardDto
+    {
+        [JsonProperty("cardId")] public string CardId { get; set; } = "";
+        [JsonProperty("unitId")] public string UnitId { get; set; } = "";
+        [JsonProperty("anchor")] public WireAnchor Anchor { get; set; } = new WireAnchor();
+        [JsonProperty("orientation")] public string Orientation { get; set; } = "north";
+        [JsonProperty("level")] public int Level { get; set; } = 1;
+        [JsonProperty("xp")] public double Xp { get; set; }
+        [JsonProperty("purchasedRound")] public int PurchasedRound { get; set; }
+        [JsonProperty("invested")] public int Invested { get; set; }
+    }
+
+    public sealed class SeatTechStateDto
+    {
+        [JsonProperty("unlockedUnits")] public List<string> UnlockedUnits { get; set; } = new List<string>();
+        [JsonProperty("purchasedTechs")] public List<string> PurchasedTechs { get; set; } = new List<string>();
+        [JsonProperty("techPriceByUnit")] public Dictionary<string, int> TechPriceByUnit { get; set; } = new Dictionary<string, int>();
+    }
+
+    public sealed class SeatViewDto
+    {
+        [JsonProperty("seat")] public int Seat { get; set; }
+        [JsonProperty("playerName")] public string PlayerName { get; set; } = "";
+        [JsonProperty("connected")] public bool Connected { get; set; }
+        [JsonProperty("commanderId")] public string? CommanderId { get; set; }
+        [JsonProperty("hp")] public int Hp { get; set; }
+        [JsonProperty("coin")] public int Coin { get; set; }
+        [JsonProperty("deploysRemaining")] public int DeploysRemaining { get; set; }
+        [JsonProperty("unlocksRemaining")] public int UnlocksRemaining { get; set; }
+        [JsonProperty("ready")] public bool Ready { get; set; }
+        [JsonProperty("cards")] public List<SquadCardDto> Cards { get; set; } = new List<SquadCardDto>();
+        [JsonProperty("tech")] public SeatTechStateDto Tech { get; set; } = new SeatTechStateDto();
+    }
+
+    public sealed class OpponentViewDto
+    {
+        [JsonProperty("seat")] public int Seat { get; set; }
+        [JsonProperty("playerName")] public string PlayerName { get; set; } = "";
+        [JsonProperty("connected")] public bool Connected { get; set; }
+        [JsonProperty("commanderId")] public string? CommanderId { get; set; }
+        [JsonProperty("hp")] public int Hp { get; set; }
+        [JsonProperty("cards")] public List<SquadCardDto> Cards { get; set; } = new List<SquadCardDto>();
+    }
+
+    public sealed class MatchConfigDto
+    {
+        [JsonProperty("board")] public BoardWH Board { get; set; } = new BoardWH();
+        [JsonProperty("deploysPerRound")] public int DeploysPerRound { get; set; }
+        [JsonProperty("unlocksPerRound")] public int UnlocksPerRound { get; set; }
+        [JsonProperty("incomePerRoundIncrement")] public int IncomePerRoundIncrement { get; set; }
+        [JsonProperty("deploySeconds")] public int DeploySeconds { get; set; }
+        [JsonProperty("battleSeconds")] public int BattleSeconds { get; set; }
+        [JsonProperty("commanderPickSeconds")] public int CommanderPickSeconds { get; set; }
+        [JsonProperty("commandersOffered")] public int CommandersOffered { get; set; }
+    }
+
+    public sealed class BoardWH
+    {
+        [JsonProperty("w")] public int W { get; set; }
+        [JsonProperty("h")] public int H { get; set; }
+    }
+
+    public sealed class MatchSnapshotDto
+    {
+        [JsonProperty("phase")] public string Phase { get; set; } = "lobby";
+        [JsonProperty("round")] public int Round { get; set; }
+        [JsonProperty("phaseDeadline")] public long PhaseDeadline { get; set; }
+        [JsonProperty("commanderOffers")] public List<string> CommanderOffers { get; set; } = new List<string>();
+        [JsonProperty("own")] public SeatViewDto Own { get; set; } = new SeatViewDto();
+        [JsonProperty("opponent")] public OpponentViewDto? Opponent { get; set; }
+    }
+
+    // -----------------------------------------------------------------------
+    // Client → server (discriminated on "type")
+    // -----------------------------------------------------------------------
+
+    public abstract class ClientMessageV2
+    {
+        [JsonProperty("type")] public abstract string Type { get; }
+
+        public static ClientMessageV2? Parse(string json)
+        {
+            var o = JObject.Parse(json);
+            var type = (string?)o["type"];
+            ClientMessageV2? msg = type switch
+            {
+                "join" => new JoinV2(),
+                "pickCommander" => new PickCommanderMsg(),
+                "buySquad" => new BuySquadMsg(),
+                "moveSquad" => new MoveSquadMsg(),
+                "sellSquad" => new SellSquadMsg(),
+                "unlockUnit" => new UnlockUnitMsg(),
+                "buyTech" => new BuyTechMsg(),
+                "buyLevel" => new BuyLevelMsg(),
+                "setReady" => new SetReadyMsg(),
+                "battleAck" => new BattleAckMsg(),
+                "ping" => new PingV2Msg(),
+                _ => null,
+            };
+            if (msg == null) return null;
+            using var reader = o.CreateReader();
+            JsonSerializer.CreateDefault().Populate(reader, msg);
+            return msg;
+        }
+    }
+
+    public sealed class JoinV2 : ClientMessageV2
+    {
+        public override string Type => "join";
+        [JsonProperty("roomId")] public string RoomId { get; set; } = "";
+        [JsonProperty("playerName")] public string PlayerName { get; set; } = "";
+        [JsonProperty("protocolVersion")] public int ProtocolVersion { get; set; }
+        [JsonProperty("resumeToken")] public string? ResumeToken { get; set; }
+        [JsonProperty("catalogHash")] public string? CatalogHash { get; set; }
+    }
+
+    public sealed class PickCommanderMsg : ClientMessageV2
+    {
+        public override string Type => "pickCommander";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("commanderId")] public string CommanderId { get; set; } = "";
+    }
+
+    public sealed class BuySquadMsg : ClientMessageV2
+    {
+        public override string Type => "buySquad";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("unitId")] public string UnitId { get; set; } = "";
+        [JsonProperty("anchor")] public WireAnchor Anchor { get; set; } = new WireAnchor();
+        [JsonProperty("orientation")] public string Orientation { get; set; } = "north";
+    }
+
+    public sealed class MoveSquadMsg : ClientMessageV2
+    {
+        public override string Type => "moveSquad";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("cardId")] public string CardId { get; set; } = "";
+        [JsonProperty("anchor")] public WireAnchor Anchor { get; set; } = new WireAnchor();
+        [JsonProperty("orientation")] public string Orientation { get; set; } = "north";
+    }
+
+    public sealed class SellSquadMsg : ClientMessageV2
+    {
+        public override string Type => "sellSquad";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("cardId")] public string CardId { get; set; } = "";
+    }
+
+    public sealed class UnlockUnitMsg : ClientMessageV2
+    {
+        public override string Type => "unlockUnit";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("unitId")] public string UnitId { get; set; } = "";
+    }
+
+    public sealed class BuyTechMsg : ClientMessageV2
+    {
+        public override string Type => "buyTech";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("unitId")] public string UnitId { get; set; } = "";
+        [JsonProperty("techId")] public string TechId { get; set; } = "";
+    }
+
+    public sealed class BuyLevelMsg : ClientMessageV2
+    {
+        public override string Type => "buyLevel";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("cardId")] public string CardId { get; set; } = "";
+    }
+
+    public sealed class SetReadyMsg : ClientMessageV2
+    {
+        public override string Type => "setReady";
+        [JsonProperty("cmdId")] public string CmdId { get; set; } = "";
+        [JsonProperty("ready")] public bool Ready { get; set; }
+    }
+
+    public sealed class BattleAckMsg : ClientMessageV2 { public override string Type => "battleAck"; }
+    public sealed class PingV2Msg : ClientMessageV2 { public override string Type => "ping"; }
+
+    // -----------------------------------------------------------------------
+    // Server → client (plain serializable objects; discriminated by "type")
+    // -----------------------------------------------------------------------
+
+    public static class ServerMsg
+    {
+        public static object Welcome(int seat, string resumeToken, string catalogJson, string catalogHash, MatchConfigDto cfg, MatchSnapshotDto? snapshot)
+            => new { type = "welcome", seat, resumeToken, catalogJson, catalogHash, matchConfig = cfg, match = snapshot };
+
+        public static object Phase(MatchSnapshotDto snapshot) => new { type = "phase", match = snapshot };
+        public static object CmdAccepted(string cmdId, MatchSnapshotDto snapshot) => new { type = "cmdAccepted", cmdId, match = snapshot };
+        public static object CmdRejected(string cmdId, string code, string message) => new { type = "cmdRejected", cmdId, code, message };
+        public static object Error(string code, string message) => new { type = "error", code, message };
+        public static object Pong() => new { type = "pong" };
+
+        public static object RevealSnapshot(int round, IEnumerable<object> armies) => new { type = "revealSnapshot", round, armies };
+        public static object BattleStarted(int round, long startAtServerMs, bool hasBattleLog) => new { type = "battleStarted", round, startAtServerMs, hasBattleLog };
+        public static object BattleLog(int round, object log) => new { type = "battleLog", round, log };
+        public static object RoundResult(int round, int? winnerSeat, IEnumerable<object> hpDamage, IEnumerable<object> hp, string summary)
+            => new { type = "roundResult", round, winnerSeat, hpDamage, hp, summary };
+        public static object MatchEnded(int? winnerSeat, IEnumerable<object> finalHp) => new { type = "matchEnded", winnerSeat, finalHp };
+    }
+}

--- a/dotnet/BoardGame.sln
+++ b/dotnet/BoardGame.sln
@@ -9,6 +9,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoardGame.BattleServer", "B
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoardGame.Core.Tests", "BoardGame.Core.Tests\BoardGame.Core.Tests.csproj", "{53B87847-6F2F-4AAD-82FB-2899F90C0B32}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BoardGame.BattleServer.Tests", "BoardGame.BattleServer.Tests\BoardGame.BattleServer.Tests.csproj", "{74AC56F1-83A9-4083-B4C3-3ED219857174}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -55,6 +57,18 @@ Global
 		{53B87847-6F2F-4AAD-82FB-2899F90C0B32}.Release|x64.Build.0 = Release|Any CPU
 		{53B87847-6F2F-4AAD-82FB-2899F90C0B32}.Release|x86.ActiveCfg = Release|Any CPU
 		{53B87847-6F2F-4AAD-82FB-2899F90C0B32}.Release|x86.Build.0 = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|x64.Build.0 = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Debug|x86.Build.0 = Debug|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|Any CPU.Build.0 = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|x64.ActiveCfg = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|x64.Build.0 = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|x86.ActiveCfg = Release|Any CPU
+		{74AC56F1-83A9-4083-B4C3-3ED219857174}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## M5 — BattleServer cutover

The production **.NET BattleServer**: the C# port of the match loop, real simulated battles at plan-lock, and SQLite persistence. VPS deployment is the only human step (see `docs/PROGRESS.md`).

**Done when: integration tests play a full match with real simulated battles; restart-resume works.** ✅

### What was done
- **Protocol V2 C# DTOs** (`Core/Runtime/Match/ProtocolV2.cs`) — hand-maintained mirror of `protocol-v2.ts`: `ClientMessageV2.Parse` (discriminated on `type`), state DTOs, server-message builders.
- **MatchRoom ported to C#** (`Core/Runtime/Match/MatchRoom.cs`) — a faithful port of the Bun reducer (same phase machine / economy / hidden planning / placement / reconnect), **structurally identical** so the ported tests confirm equivalence. At plan-lock it **runs the Core sim** and exposes the real event log. Adds `CaptureState`/`RestoreState` + `MatchRoomSnapshot` for persistence.
- **BattleServer** (`dotnet/BoardGame.BattleServer`) — ASP.NET Core minimal host: `/health`, a `/ws` protocol-V2 endpoint (shared `WebSocketEndpoint.Map`), a `PeriodicTimer` deadline ticker, and a **per-room lock** making each room a single-threaded actor (no command-interleave race). Ships `revealSnapshot` + `battleStarted` + **`battleLog`** + `roundResult` at plan-lock. Newtonsoft throughout.
- **SQLite persistence** (`RoomStore.cs`) — `IRoomStore` + `SqliteRoomStore` (one upserted row per room at every transition + a match archive) + `InMemoryRoomStore`. `BOARDGAME_DB` selects SQLite.
- **Ported conformance suite** (`BoardGame.BattleServer.Tests`, real Kestrel + real `ClientWebSocket`): `/health` protocol v2, welcome with catalog bytes, a **full round producing a real battleLog** (`hasBattleLog: true` — the cutover signal), command rejection, and **restart-resume** (capture/restore round-trip, SQLite survives a reopen with reconnect tokens intact, hub resumes a room from the store).

### How it was verified
- `dotnet test` → **44/44 green** (37 Core incl. 11 ported MatchRoom + 7 BattleServer integration), **stable across 6+ isolated and 4+ full-solution runs** — the earlier flake was a racing-seat test bug (buys landing `outsideOwnHalf`), fixed via sequential seat-aware joins + the per-room actor lock.
- The real BattleServer binary boots with SQLite, `/health` returns protocol v2 + the embedded-catalog hash + creates the DB.
- `dotnet publish -c Release -r <rid> --self-contained` → a single deployable binary.
- `turbo run build test --filter=battle-server` green; TS pipeline green; `format:check` clean.

### ⏭️ Deferred to a human
- **VPS deployment** (Hetzner/Fly, credentials + DNS) — the self-contained binary / container path is ready; publishing to a host is an ops step.
- **Retiring `apps/game-server` + retargeting `bun dev`** — kept intentionally: the Bun match server is the reference spec (its tests still gate CI); the cutover is a deploy switch, not a code deletion. The client sees the same protocol V2; only `battleLog` now appears.
- A real cross-network match on two phones against the deployed server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEQ5sQKX7Mid8FfmzBJv6i