### PR TITLE
Commit Unity import artifacts for com.boardgame.core

### DIFF
--- a/apps/game-client/.vscode/settings.json
+++ b/apps/game-client/.vscode/settings.json
@@ -56,5 +56,5 @@
         "temp/": true,
         "Temp/": true
     },
-    "dotnet.defaultSolution": "battleship_game.sln"
+    "dotnet.defaultSolution": "game-client.sln"
 }

--- a/apps/game-client/Assets/StreamingAssets.meta
+++ b/apps/game-client/Assets/StreamingAssets.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b199a3d59478e46a79c1209cedc7fe0c
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/apps/game-client/Assets/StreamingAssets/catalog.hash.meta
+++ b/apps/game-client/Assets/StreamingAssets/catalog.hash.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3f14bac15f1ee40ed9b1ea5ff49df8da
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/apps/game-client/Assets/StreamingAssets/catalog.json.meta
+++ b/apps/game-client/Assets/StreamingAssets/catalog.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6903914caed00453797d55accba8e084
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/apps/game-client/Packages/packages-lock.json
+++ b/apps/game-client/Packages/packages-lock.json
@@ -1,5 +1,13 @@
 {
   "dependencies": {
+    "com.boardgame.core": {
+      "version": "file:../../../dotnet/BoardGame.Core",
+      "depth": 0,
+      "source": "local",
+      "dependencies": {
+        "com.unity.nuget.newtonsoft-json": "3.2.1"
+      }
+    },
     "com.unity.ai.navigation": {
       "version": "2.0.5",
       "depth": 0,
@@ -90,6 +98,13 @@
     "com.unity.nuget.mono-cecil": {
       "version": "1.11.4",
       "depth": 3,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.nuget.newtonsoft-json": {
+      "version": "3.2.1",
+      "depth": 0,
       "source": "registry",
       "dependencies": {},
       "url": "https://packages.unity.com"

--- a/dotnet/BoardGame.Core/BoardGame.Core.csproj.meta
+++ b/dotnet/BoardGame.Core/BoardGame.Core.csproj.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6cd05386a3cae474a81f9cc56a5204fa
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime.meta
+++ b/dotnet/BoardGame.Core/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 52d5afc061850459ea9496fd009afb5f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/BoardGame.Core.asmdef.meta
+++ b/dotnet/BoardGame.Core/Runtime/BoardGame.Core.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 8ec19a7ba5b474e6389158e4bd691203
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/Catalog.meta
+++ b/dotnet/BoardGame.Core/Runtime/Catalog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 47ab946a560f44780a6fd2bf614f08a4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/Catalog/CatalogDto.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Catalog/CatalogDto.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: d10e3942eca1f4a2f93060f750d3c7b3

--- a/dotnet/BoardGame.Core/Runtime/Catalog/CatalogLoader.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Catalog/CatalogLoader.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: e5be8ecafbe9e4184b286ee5f69514fc

--- a/dotnet/BoardGame.Core/Runtime/Catalog/Footprint.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Catalog/Footprint.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a0957eabfbe6d4ff495118bcb91236ca

--- a/dotnet/BoardGame.Core/Runtime/EngineInfo.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/EngineInfo.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: b3eaa4346f9a64525a8f9cbc717d4afa

--- a/dotnet/BoardGame.Core/Runtime/Events.meta
+++ b/dotnet/BoardGame.Core/Runtime/Events.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 79758bbce68c54b6d99d96ad45c88dd6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/Events/BattleEvent.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Events/BattleEvent.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: c00f15b39864c48309800996746a2060

--- a/dotnet/BoardGame.Core/Runtime/Match.meta
+++ b/dotnet/BoardGame.Core/Runtime/Match.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 71d580ef88c7a491b92bbbdcf652fa42
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/Match/MatchRoom.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Match/MatchRoom.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 2c1cce4651bdc4de3a772a371e9f6ac9

--- a/dotnet/BoardGame.Core/Runtime/Match/Placement.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Match/Placement.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 0ea0986cd9b3e481aa3c14083a840eb5

--- a/dotnet/BoardGame.Core/Runtime/Match/ProtocolV2.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Match/ProtocolV2.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: db0b4462d7844495aab527e4cf084268

--- a/dotnet/BoardGame.Core/Runtime/Sim.meta
+++ b/dotnet/BoardGame.Core/Runtime/Sim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9a426614336484fc78ff6b6d3f528872
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/dotnet/BoardGame.Core/Runtime/Sim/BattleSetup.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Sim/BattleSetup.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 71754b950616942408a3fb46af0156d8

--- a/dotnet/BoardGame.Core/Runtime/Sim/BattleSim.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Sim/BattleSim.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 04630a1b13bdd45b78cdb72fc50a506a

--- a/dotnet/BoardGame.Core/Runtime/Sim/BattleState.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Sim/BattleState.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: f4cb0a7662393476680eefd4f9c3cbb6

--- a/dotnet/BoardGame.Core/Runtime/Sim/XorShiftRng.cs.meta
+++ b/dotnet/BoardGame.Core/Runtime/Sim/XorShiftRng.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: be77f59c07b044a47b38b0ea1ab2236a

--- a/dotnet/BoardGame.Core/package.json.meta
+++ b/dotnet/BoardGame.Core/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 4160cfaabd6624a0c9c09f9516da5b5e
+PackageManifestImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Unity import artifacts

Generated when the `apps/game-client` project was first opened in the Unity Editor, which imported the local `com.boardgame.core` UPM package + Newtonsoft.

### What's included
- **`.meta` files** for every folder/file under `dotnet/BoardGame.Core/Runtime/` and for `StreamingAssets/catalog.json` + `.hash`. Committing them locks in stable Unity asset GUIDs so references don't break across machines or re-imports.
- **`Packages/packages-lock.json`** — Unity's resolution of the `com.boardgame.core` `file:` dependency + `com.unity.nuget.newtonsoft-json`.
- **`.vscode/settings.json`** — Unity corrected a stale `dotnet.defaultSolution` (`battleship_game.sln` → `game-client.sln`) left over from the original project this was derived from.

### Verification
No source or behavior changes. `dotnet build` and `biome format:check` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VEQ5sQKX7Mid8FfmzBJv6i