### PR TITLE
Two-client shared board: server-authoritative rendering in the Unity client

### DIFF
--- a/apps/game-client/Assets/BoardGame/Materials.meta
+++ b/apps/game-client/Assets/BoardGame/Materials.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d7155f3d96fd498588faa9e322c27f31
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat
+++ b/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-447249437258523261
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -21,7 +34,7 @@ Material:
     RenderType: Opaque
   disabledShaderPasses:
   - MOTIONVECTORS
-  m_LockedProperties:
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:

--- a/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat
+++ b/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat
@@ -1,0 +1,42 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MineUnit
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties:
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Cutoff: 0.5
+    - _Metallic: 0
+    - _Smoothness: 0.5
+    - _Surface: 0
+    m_Colors:
+    - _BaseColor: {r: 0.2, g: 0.7, b: 0.65, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat.meta
+++ b/apps/game-client/Assets/BoardGame/Materials/MineUnit.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6711111d9a5149618d1022910d0e3319
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat
+++ b/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat
@@ -1,0 +1,42 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: TheirsUnit
+  m_Shader: {fileID: 4800000, guid: 933532a4fcc9baf4fa0491de14d08ed7, type: 3}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 1
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap:
+    RenderType: Opaque
+  disabledShaderPasses:
+  - MOTIONVECTORS
+  m_LockedProperties:
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BaseMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _Cutoff: 0.5
+    - _Metallic: 0
+    - _Smoothness: 0.5
+    - _Surface: 0
+    m_Colors:
+    - _BaseColor: {r: 0.8, g: 0.35, b: 0.2, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []
+  m_AllowLocking: 1

--- a/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat
+++ b/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat
@@ -1,5 +1,18 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-5180698158099038594
+MonoBehaviour:
+  m_ObjectHideFlags: 11
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0353a89b1f911e48b9e16bdc9f2e058, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  version: 9
 --- !u!21 &2100000
 Material:
   serializedVersion: 8
@@ -21,7 +34,7 @@ Material:
     RenderType: Opaque
   disabledShaderPasses:
   - MOTIONVECTORS
-  m_LockedProperties:
+  m_LockedProperties: 
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:

--- a/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat.meta
+++ b/apps/game-client/Assets/BoardGame/Materials/TheirsUnit.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 530c9bfea0de4706ac0b20e2a4f337de
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/apps/game-client/Assets/BoardGame/Scripts/BoardManager.cs
+++ b/apps/game-client/Assets/BoardGame/Scripts/BoardManager.cs
@@ -1,12 +1,45 @@
 using UnityEngine;
 using System.Collections.Generic;
+using BoardGame.Net;
 
+/// <summary>
+/// Renders a shared, server-authoritative board. The client never mutates the
+/// board directly: a placement-mode click asks the server to place a unit, and
+/// the board is redrawn from the state the server broadcasts back to every
+/// client in the room. Two clients therefore can never disagree — both mirror
+/// the same broadcast.
+///
+/// The tile grid is built from the board size the server reports
+/// (<see cref="GameStateDto.board"/>), not a hardcoded constant, and every unit
+/// is tinted by ownership (mine vs. theirs) so open, color-coded placement is
+/// visible on both screens.
+///
+/// Editor wiring (see docs/two-client-shared-board-plan.md §3): drop a
+/// GameServerClient onto a "Net" GameObject, drag it into <see cref="client"/>,
+/// and assign the Mine/Theirs materials.
+/// </summary>
 public class BoardManager : MonoBehaviour
 {
     public Transform ParentTransform;
     public GameObject BoardTilePrefab;
 
+    [Header("Networking")]
+    [Tooltip("The GameServerClient this board mirrors. Assign in the Editor (see plan §3).")]
+    [SerializeField] private GameServerClient client;
+
+    [Header("Ownership Tint")]
+    [Tooltip("Material applied to units owned by this client. Optional — if unset, mineColor is used as a per-renderer tint.")]
+    [SerializeField] private Material mineMaterial;
+    [Tooltip("Material applied to units owned by other clients in the room. Optional — if unset, theirsColor is used as a per-renderer tint.")]
+    [SerializeField] private Material theirsMaterial;
+    [Tooltip("Fallback tint for my units when Mine Material is unassigned.")]
+    [SerializeField] private Color mineColor = new Color(0.20f, 0.70f, 0.65f);   // teal
+    [Tooltip("Fallback tint for opponent units when Theirs Material is unassigned.")]
+    [SerializeField] private Color theirsColor = new Color(0.80f, 0.35f, 0.20f); // clay
+
     [Header("Unit Details")]
+    // NOTE: these field names/types are referenced by GUID in SampleScene.unity.
+    // Do not rename them or the scene's serialized asset references will break.
     public CathedralDetails cathedralDetails;
     public BarracksDetails barracksDetails;
     public HolyKnightDetails holyKnightDetails;
@@ -14,33 +47,310 @@ public class BoardManager : MonoBehaviour
     public ArcherDetails archerDetails;
     public WhelpDetails whelpDetails;
 
-    private const int BOARD_WIDTH = 32;
-    private const int BOARD_HEIGHT = 32;
+    // Catalog unit-type id -> visual details. Built in Awake from the serialized
+    // *Details fields. Keys must match the server catalog ids (core/catalog).
+    private Dictionary<string, IUnitDetails> detailsByType;
+
+    // Units currently drawn, keyed by the SERVER's unit id, so a fresh broadcast
+    // can be diffed against what is on screen (spawn new, move/retype = respawn,
+    // despawn removed).
+    private readonly Dictionary<string, RenderedUnit> rendered = new Dictionary<string, RenderedUnit>();
 
     private GameObject[,] gameTiles;
-    private Unit[,] tileOccupancy;
-    private List<Unit> player1Units;
-    private List<Unit> player2Units;
-    private bool isHolyKnightPlacementMode = false;
-    private bool isFootmanPlacementMode = false;
-    private bool isArcherPlacementMode = false;
-    private bool isWhelpPlacementMode = false;
+    private int boardW = GameProtocol.BoardWidth;   // pre-connect fallback; overwritten from welcome/state
+    private int boardH = GameProtocol.BoardHeight;
+    private bool gridBuilt = false;
 
-    void Start()
+    private string myPlayerId;
+    // The unit type the next tile click will request, or null when just
+    // inspecting. Replaces the old per-type placement-mode booleans.
+    private string selectedUnitType = null;
+
+    /// <summary>A drawn unit: its root GameObject plus the last state we drew it from.</summary>
+    private class RenderedUnit
     {
-        InitializeBoard();
+        public GameObject root;
+        public UnitDto last;
     }
 
-    void InitializeBoard()
+    void Awake()
     {
-        gameTiles = new GameObject[BOARD_WIDTH, BOARD_HEIGHT];
-        tileOccupancy = new Unit[BOARD_WIDTH, BOARD_HEIGHT];
-        player1Units = new List<Unit>();
-        player2Units = new List<Unit>();
-
-        for (int x = 0; x < BOARD_WIDTH; x++)
+        detailsByType = new Dictionary<string, IUnitDetails>
         {
-            for (int y = 0; y < BOARD_HEIGHT; y++)
+            [GameProtocol.UnitFootman] = footmanDetails,
+            [GameProtocol.UnitArcher] = archerDetails,
+            [GameProtocol.UnitWhelp] = whelpDetails,
+            [GameProtocol.UnitHolyKnight] = holyKnightDetails,
+            [GameProtocol.UnitBarracks] = barracksDetails,
+            [GameProtocol.UnitCathedral] = cathedralDetails,
+        };
+
+        if (client == null)
+        {
+            Debug.LogError("[BoardManager] Client is not assigned. Drag the Net GameObject " +
+                "(GameServerClient) into BoardManager's Client field — see plan §3. " +
+                "The board will stay empty until it is wired.");
+        }
+    }
+
+    void OnEnable()
+    {
+        if (client == null) return;
+        client.WelcomeReceived += OnWelcome;
+        client.StateReceived += OnState;
+        client.ErrorReceived += OnError;
+    }
+
+    void OnDisable()
+    {
+        if (client == null) return;
+        client.WelcomeReceived -= OnWelcome;
+        client.StateReceived -= OnState;
+        client.ErrorReceived -= OnError;
+    }
+
+    // ------------------------------------------------------------------
+    // Server events (all raised on the main thread by GameServerClient)
+    // ------------------------------------------------------------------
+
+    private void OnWelcome(WelcomeMessage w)
+    {
+        myPlayerId = w.playerId;
+        // Welcome carries the full state; RenderState (re)builds the grid and
+        // draws every unit already in the room, so late joiners are correct.
+        RenderState(w.state);
+    }
+
+    private void OnState(GameStateDto s)
+    {
+        RenderState(s);
+    }
+
+    private void OnError(ErrorMessage e)
+    {
+        // A rejected placement produces no state change, so nothing is drawn —
+        // exactly right. Surface the reason for the player who acted.
+        Debug.LogWarning($"[BoardManager] Placement rejected — {e.code}: {e.message}");
+    }
+
+    // ------------------------------------------------------------------
+    // Rendering
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Reconcile the drawn board with an authoritative snapshot. Diffs by unit
+    /// id: unchanged units are left alone, moved/retyped units are respawned,
+    /// and units the server no longer reports are removed.
+    /// </summary>
+    private void RenderState(GameStateDto s)
+    {
+        if (s == null) return;
+
+        if (s.board != null)
+        {
+            EnsureGrid(s.board.width, s.board.height);
+        }
+        else if (!gridBuilt)
+        {
+            EnsureGrid(boardW, boardH);
+        }
+
+        var seen = new HashSet<string>();
+        if (s.units != null)
+        {
+            foreach (var unit in s.units)
+            {
+                if (unit == null || string.IsNullOrEmpty(unit.id)) continue;
+                seen.Add(unit.id);
+
+                if (rendered.TryGetValue(unit.id, out var existing))
+                {
+                    if (Changed(existing.last, unit))
+                    {
+                        // Simplest correct reconciliation: destroy and respawn
+                        // at the new spot / type / owner.
+                        Destroy(existing.root);
+                        rendered[unit.id] = SpawnUnit(unit);
+                    }
+                    // else unchanged — leave it in place.
+                }
+                else
+                {
+                    rendered[unit.id] = SpawnUnit(unit);
+                }
+            }
+        }
+
+        // Remove anything the server no longer reports (sold, or owner left).
+        if (rendered.Count != seen.Count)
+        {
+            var stale = new List<string>();
+            foreach (var id in rendered.Keys)
+            {
+                if (!seen.Contains(id)) stale.Add(id);
+            }
+            foreach (var id in stale)
+            {
+                Destroy(rendered[id].root);
+                rendered.Remove(id);
+            }
+        }
+    }
+
+    private static bool Changed(UnitDto a, UnitDto b)
+    {
+        return a.row != b.row || a.col != b.col ||
+               a.unitType != b.unitType || a.ownerId != b.ownerId;
+    }
+
+    /// <summary>
+    /// Spawn the visual for one server unit and return its handle. Known unit
+    /// types use their squad formation; unknown types fall back to a tinted
+    /// footprint-sized placeholder so a server-added type never crashes us.
+    /// </summary>
+    private RenderedUnit SpawnUnit(UnitDto u)
+    {
+        bool mine = (u.ownerId == myPlayerId);
+
+        var squadParent = new GameObject($"{u.ownerId}_{u.unitType}_{u.id}");
+        // false: keep the parent's transform; we position models in world space.
+        if (ParentTransform != null)
+        {
+            squadParent.transform.SetParent(ParentTransform, false);
+        }
+
+        IUnitDetails details = null;
+        if (detailsByType != null)
+        {
+            detailsByType.TryGetValue(u.unitType, out details);
+        }
+
+        if (details != null && details.ModelPrefab != null)
+        {
+            SpawnSquad(u, details, mine, squadParent.transform);
+        }
+        else
+        {
+            // Unknown type, or a known type whose prefab isn't assigned.
+            SpawnPlaceholder(u, details, mine, squadParent.transform);
+        }
+
+        return new RenderedUnit { root = squadParent, last = u };
+    }
+
+    private void SpawnSquad(UnitDto u, IUnitDetails details, bool mine, Transform parent)
+    {
+        // Opponent squads face back toward this client (replaces the old
+        // Player.Player2 branch — keyed on ownership, not a hardcoded enum).
+        Quaternion rotation = details.ModelRotation;
+        if (!mine)
+        {
+            rotation = Quaternion.Euler(0, 180, 0) * rotation;
+        }
+
+        Vector3 basePosition = new Vector3(u.row, details.ModelHeight, u.col);
+        Vector3[] squadFormation = details.GetSquadFormation();
+
+        for (int i = 0; i < squadFormation.Length; i++)
+        {
+            Vector3 worldPosition = basePosition + squadFormation[i] + details.ModelPositionOffset;
+            GameObject model = Instantiate(details.ModelPrefab, worldPosition, rotation);
+            model.name = $"{details.UnitName}_{i}";
+            model.transform.SetParent(parent, true);
+            ApplyTint(model, mine);
+        }
+    }
+
+    /// <summary>
+    /// A tinted cube sized to the unit's footprint, used when we cannot resolve
+    /// a model prefab for a unit type. Never throws.
+    /// </summary>
+    private void SpawnPlaceholder(UnitDto u, IUnitDetails details, bool mine, Transform parent)
+    {
+        Vector2Int footprint = details != null ? details.FootprintSize : new Vector2Int(1, 1);
+        if (footprint.x < 1) footprint.x = 1;
+        if (footprint.y < 1) footprint.y = 1;
+
+        var cube = GameObject.CreatePrimitive(PrimitiveType.Cube);
+        cube.name = $"placeholder_{u.unitType}";
+        // CreatePrimitive attaches a BoxCollider; drop it so the placeholder
+        // never intercepts the placement raycast (which looks for BoardTile).
+        var collider = cube.GetComponent<Collider>();
+        if (collider != null) Destroy(collider);
+        // Cube spans the footprint (Unity cube is 1x1x1); centre it over the
+        // footprint's tiles with a modest height.
+        cube.transform.localScale = new Vector3(footprint.x, 0.5f, footprint.y);
+        cube.transform.position = new Vector3(
+            u.row + (footprint.x - 1) * 0.5f,
+            0.25f,
+            u.col + (footprint.y - 1) * 0.5f);
+        cube.transform.SetParent(parent, true);
+        ApplyTint(cube, mine);
+    }
+
+    /// <summary>
+    /// Colour a spawned object by ownership. Prefers the assigned Mine/Theirs
+    /// material; when that slot is unassigned, falls back to a per-renderer
+    /// colour (via MaterialPropertyBlock) so ownership is still visible during
+    /// guided setup. The property block only overrides the base colour and never
+    /// clones or mutates a shared material asset.
+    /// </summary>
+    private void ApplyTint(GameObject go, bool mine)
+    {
+        var renderers = go.GetComponentsInChildren<Renderer>(true);
+        if (renderers.Length == 0) return;
+
+        Material tint = mine ? mineMaterial : theirsMaterial;
+        if (tint != null)
+        {
+            foreach (var r in renderers)
+            {
+                r.sharedMaterial = tint;
+            }
+            return;
+        }
+
+        // Fallback: no material wired yet — tint the base colour so mine vs
+        // theirs is still distinguishable. URP Lit uses "_BaseColor"; the
+        // Standard/legacy shader uses "_Color". Set both so either pipeline
+        // shows the tint.
+        Color color = mine ? mineColor : theirsColor;
+        var block = new MaterialPropertyBlock();
+        foreach (var r in renderers)
+        {
+            r.GetPropertyBlock(block);
+            block.SetColor("_BaseColor", color);
+            block.SetColor("_Color", color);
+            r.SetPropertyBlock(block);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Grid
+    // ------------------------------------------------------------------
+
+    /// <summary>
+    /// Build (or rebuild) the tile grid to the given dimensions. No-op if the
+    /// grid already matches. Rebuilding clears any drawn units — the next
+    /// RenderState call redraws them from the authoritative snapshot.
+    /// </summary>
+    private void EnsureGrid(int width, int height)
+    {
+        if (width <= 0 || height <= 0) return;
+        if (gridBuilt && width == boardW && height == boardH) return;
+
+        if (gridBuilt)
+        {
+            ClearGrid();
+        }
+
+        boardW = width;
+        boardH = height;
+        gameTiles = new GameObject[boardW, boardH];
+
+        for (int x = 0; x < boardW; x++)
+        {
+            for (int y = 0; y < boardH; y++)
             {
                 Vector3 position = new Vector3(x, 0, y);
                 GameObject tile = Instantiate(BoardTilePrefab, position, Quaternion.identity);
@@ -49,265 +359,103 @@ public class BoardManager : MonoBehaviour
                 {
                     tile.transform.SetParent(ParentTransform, false);
                 }
-                string captionText = string.Format("B1:[{0:00},{1:00}]", x, y);
 
-                #region Board Tile
+                string captionText = string.Format("B1:[{0:00},{1:00}]", x, y);
                 BoardTile tileUI = tile.GetComponentInChildren<BoardTile>();
-                tileUI.boardTileCaptionText.text = captionText;
-                tileUI.col = y;
-                tileUI.row = x;
-                #endregion
+                if (tileUI != null)
+                {
+                    tileUI.boardTileCaptionText.text = captionText;
+                    tileUI.col = y;
+                    tileUI.row = x;
+                }
 
                 gameTiles[x, y] = tile;
             }
         }
 
-        // Place units on the board
-        PlaceUnit(cathedralDetails, Player.Player1, 8, 5);
-        PlaceUnit(barracksDetails, Player.Player1, 22, 5);
-        PlaceUnit(barracksDetails, Player.Player2, 8, 26);
-        PlaceUnit(cathedralDetails, Player.Player2, 22, 26);
+        gridBuilt = true;
     }
 
-    Unit PlaceUnit(IUnitDetails unitDetails, Player owner, int startX, int startY)
+    private void ClearGrid()
     {
-        if (unitDetails == null)
+        if (gameTiles == null) return;
+        for (int x = 0; x < gameTiles.GetLength(0); x++)
         {
-            Debug.LogWarning($"Unit details is null, cannot place at ({startX}, {startY})");
-            return null;
+            for (int y = 0; y < gameTiles.GetLength(1); y++)
+            {
+                if (gameTiles[x, y] != null) Destroy(gameTiles[x, y]);
+            }
         }
 
-        Vector2Int footprint = unitDetails.FootprintSize;
-
-        // Check bounds
-        if (startX < 0 || startY < 0 ||
-            startX + footprint.x > BOARD_WIDTH ||
-            startY + footprint.y > BOARD_HEIGHT)
+        // Drawn units are children of the grid's world; drop their handles so
+        // RenderState redraws them fresh against the rebuilt grid.
+        foreach (var ru in rendered.Values)
         {
-            Debug.LogError($"Unit placement out of bounds at ({startX}, {startY}) with size {footprint.x}x{footprint.y}");
-            return null;
+            if (ru.root != null) Destroy(ru.root);
         }
-
-        // Check if tiles are occupied
-        if (!AreTilesAvailable(startX, startY, footprint))
-        {
-            Debug.LogError($"Tiles at ({startX}, {startY}) are already occupied");
-            return null;
-        }
-
-        // Create Unit instance
-        Unit unit = new Unit(owner, unitDetails, new Vector2Int(startX, startY));
-
-        // Determine rotation (Player 2 units face opposite direction)
-        Quaternion rotation = unitDetails.ModelRotation;
-        if (owner == Player.Player2)
-        {
-            rotation = Quaternion.Euler(0, 180, 0) * rotation;
-        }
-
-        // Get squad formation and spawn models
-        Vector3[] squadFormation = unitDetails.GetSquadFormation();
-        GameObject squadParent = new GameObject($"{owner}_{unitDetails.UnitName}_{startX}_{startY}");
-        squadParent.transform.SetParent(ParentTransform, true);
-
-        for (int i = 0; i < squadFormation.Length; i++)
-        {
-            // Calculate world position for each model in the squad
-            Vector3 basePosition = new Vector3(startX, unitDetails.ModelHeight, startY);
-            Vector3 formationOffset = squadFormation[i];
-            Vector3 worldPosition = basePosition + formationOffset + unitDetails.ModelPositionOffset;
-
-            GameObject model = Instantiate(
-                unitDetails.ModelPrefab,
-                worldPosition,
-                rotation
-            );
-            model.name = $"{unitDetails.UnitName}_{i}";
-            model.transform.SetParent(squadParent.transform, true);
-        }
-
-        unit.VisualInstance = squadParent;
-
-        // Mark tiles as occupied
-        MarkTilesOccupied(unit, startX, startY, footprint);
-
-        // Add to appropriate player's unit list
-        if (owner == Player.Player1)
-            player1Units.Add(unit);
-        else
-            player2Units.Add(unit);
-
-        Debug.Log($"Placed {owner} {unitDetails.UnitName} at ({startX}, {startY})");
-        return unit;
-    }
-
-    bool AreTilesAvailable(int startX, int startY, Vector2Int footprint)
-    {
-        for (int x = startX; x < startX + footprint.x; x++)
-            for (int y = startY; y < startY + footprint.y; y++)
-                if (tileOccupancy[x, y] != null)
-                    return false;
-        return true;
-    }
-
-    void MarkTilesOccupied(Unit unit, int startX, int startY, Vector2Int footprint)
-    {
-        for (int x = startX; x < startX + footprint.x; x++)
-            for (int y = startY; y < startY + footprint.y; y++)
-                tileOccupancy[x, y] = unit;
-    }
-
-    void ClearTileOccupancy(Unit unit)
-    {
-        Vector2Int footprint = unit.UnitDetails.FootprintSize;
-        Vector2Int pos = unit.PlacementPosition;
-        for (int x = pos.x; x < pos.x + footprint.x; x++)
-            for (int y = pos.y; y < pos.y + footprint.y; y++)
-                if (tileOccupancy[x, y] == unit)
-                    tileOccupancy[x, y] = null;
-    }
-
-    public Unit GetUnitAtPosition(int x, int y)
-    {
-        if (x >= 0 && x < BOARD_WIDTH && y >= 0 && y < BOARD_HEIGHT)
-            return tileOccupancy[x, y];
-        return null;
+        rendered.Clear();
+        gameTiles = null;
     }
 
     public GameObject GetTile(int x, int y)
     {
-        if (x >= 0 && x < BOARD_WIDTH && y >= 0 && y < BOARD_HEIGHT)
+        if (gameTiles != null && x >= 0 && x < boardW && y >= 0 && y < boardH)
         {
             return gameTiles[x, y];
         }
         return null;
     }
 
-    public void ToggleHolyKnightPlacementMode()
-    {
-        isHolyKnightPlacementMode = !isHolyKnightPlacementMode;
-        Debug.Log($"Holy Knight placement mode: {(isHolyKnightPlacementMode ? "ON" : "OFF")}");
-    }
+    // ------------------------------------------------------------------
+    // Placement input — scene buttons call these Toggle* methods by name.
+    // Signatures must not change or SampleScene.unity's button wiring breaks.
+    // ------------------------------------------------------------------
 
-    public void ToggleFootmanPlacementMode()
-    {
-        isFootmanPlacementMode = !isFootmanPlacementMode;
-        Debug.Log($"Footman placement mode: {(isFootmanPlacementMode ? "ON" : "OFF")}");
-    }
+    public void ToggleHolyKnightPlacementMode() => SetSelected(GameProtocol.UnitHolyKnight);
+    public void ToggleFootmanPlacementMode() => SetSelected(GameProtocol.UnitFootman);
+    public void ToggleArcherPlacementMode() => SetSelected(GameProtocol.UnitArcher);
+    public void ToggleWhelpPlacementMode() => SetSelected(GameProtocol.UnitWhelp);
 
-    public void ToggleArcherPlacementMode()
+    /// <summary>Select a unit type, or toggle it off if it was already selected.</summary>
+    private void SetSelected(string unitType)
     {
-        isArcherPlacementMode = !isArcherPlacementMode;
-        Debug.Log($"Archer placement mode: {(isArcherPlacementMode ? "ON" : "OFF")}");
-    }
-
-    public void ToggleWhelpPlacementMode()
-    {
-        isWhelpPlacementMode = !isWhelpPlacementMode;
-        Debug.Log($"Whelp placement mode: {(isWhelpPlacementMode ? "ON" : "OFF")}");
+        selectedUnitType = (selectedUnitType == unitType) ? null : unitType;
+        Debug.Log(selectedUnitType == null
+            ? "[BoardManager] Placement mode OFF."
+            : $"[BoardManager] Placement mode: {selectedUnitType}");
     }
 
     void Update()
     {
-        Ray ray = Camera.main.ScreenPointToRay(Input.mousePosition);
+        if (!Input.GetMouseButtonDown(0)) return;
 
-        #region MOUSE CLICK
-        if (Input.GetMouseButtonDown(0))
+        Camera cam = Camera.main;
+        if (cam == null) return;
+
+        Ray ray = cam.ScreenPointToRay(Input.mousePosition);
+        if (!Physics.Raycast(ray, out RaycastHit hit, 200f)) return;
+        if (!hit.transform.CompareTag("BoardTile")) return;
+
+        var bt = hit.transform.GetComponent<BoardTile>();
+        if (bt == null) return;
+
+        if (selectedUnitType == null)
         {
-            RaycastHit hit;
-            if (Physics.Raycast(ray, out hit, 200))
-            {
-                if (hit.transform.tag.Equals("BoardTile"))
-                {
-                    var bt = hit.transform.GetComponent<BoardTile>();
-
-                    if (isHolyKnightPlacementMode)
-                    {
-                        // Place Holy Knight at this tile
-                        // Note: bt.row stores x coordinate, bt.col stores y coordinate
-                        int tileX = bt.row;
-                        int tileY = bt.col;
-
-                        Debug.Log($"Attempting to place Holy Knight at tile ({tileX}, {tileY})");
-
-                        // Check if tile is empty
-                        if (GetUnitAtPosition(tileX, tileY) == null)
-                        {
-                            PlaceUnit(holyKnightDetails, Player.Player1, tileX, tileY);
-                            isHolyKnightPlacementMode = false; // Exit placement mode after placing
-                            Debug.Log($"Placed Holy Knight at ({tileX}, {tileY}). Placement mode OFF.");
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"Cannot place Holy Knight at ({tileX}, {tileY}) - tile is occupied");
-                        }
-                    }
-                    else if (isFootmanPlacementMode)
-                    {
-                        // Place Footman at this tile
-                        // Note: bt.row stores x coordinate, bt.col stores y coordinate
-                        int tileX = bt.row;
-                        int tileY = bt.col;
-
-                        Debug.Log($"Attempting to place Footman at tile ({tileX}, {tileY})");
-
-                        // Check if tile is empty
-                        if (GetUnitAtPosition(tileX, tileY) == null)
-                        {
-                            PlaceUnit(footmanDetails, Player.Player1, tileX, tileY);
-                            isFootmanPlacementMode = false; // Exit placement mode after placing
-                            Debug.Log($"Placed Footman at ({tileX}, {tileY}). Placement mode OFF.");
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"Cannot place Footman at ({tileX}, {tileY}) - tile is occupied");
-                        }
-                    }
-                    else if (isArcherPlacementMode)
-                    {
-                        // Place Archer at this tile
-                        int tileX = bt.row;
-                        int tileY = bt.col;
-
-                        Debug.Log($"Attempting to place Archer at tile ({tileX}, {tileY})");
-
-                        if (GetUnitAtPosition(tileX, tileY) == null)
-                        {
-                            PlaceUnit(archerDetails, Player.Player1, tileX, tileY);
-                            isArcherPlacementMode = false;
-                            Debug.Log($"Placed Archer at ({tileX}, {tileY}). Placement mode OFF.");
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"Cannot place Archer at ({tileX}, {tileY}) - tile is occupied");
-                        }
-                    }
-                    else if (isWhelpPlacementMode)
-                    {
-                        // Place Whelp at this tile
-                        int tileX = bt.row;
-                        int tileY = bt.col;
-
-                        Debug.Log($"Attempting to place Whelp at tile ({tileX}, {tileY})");
-
-                        if (GetUnitAtPosition(tileX, tileY) == null)
-                        {
-                            PlaceUnit(whelpDetails, Player.Player1, tileX, tileY);
-                            isWhelpPlacementMode = false;
-                            Debug.Log($"Placed Whelp at ({tileX}, {tileY}). Placement mode OFF.");
-                        }
-                        else
-                        {
-                            Debug.LogWarning($"Cannot place Whelp at ({tileX}, {tileY}) - tile is occupied");
-                        }
-                    }
-                    else
-                    {
-                        Debug.Log(bt.boardTileCaptionText.text);
-                    }
-                }
-            }
+            // Just inspecting.
+            if (bt.boardTileCaptionText != null) Debug.Log(bt.boardTileCaptionText.text);
+            return;
         }
-        #endregion MOUSE CLICK
+
+        if (client == null)
+        {
+            Debug.LogWarning("[BoardManager] No client assigned; cannot place. See plan §3.");
+            return;
+        }
+
+        // bt.row is the world-X tile index, bt.col the world-Z index — the same
+        // convention the server uses. Ask the server; do NOT spawn locally. The
+        // unit appears only when the server's state broadcast comes back.
+        client.SendPlaceUnit(selectedUnitType, bt.row, bt.col);
+        selectedUnitType = null; // one placement per selection
     }
 }

--- a/apps/game-client/Assets/BoardGame/Scripts/Net/GameProtocol.cs
+++ b/apps/game-client/Assets/BoardGame/Scripts/Net/GameProtocol.cs
@@ -8,12 +8,19 @@ namespace BoardGame.Net
     /// text frames, discriminated by their "type" field.
     ///
     /// Board convention (matches BoardManager/BoardTile): "row" is the world-X
-    /// tile index (0..71) and "col" is the world-Z tile index (0..59).
+    /// tile index (the wide/lateral axis) and "col" is the world-Z tile index
+    /// (the deep axis). The AUTHORITATIVE board size is whatever the server
+    /// sends in <see cref="GameStateDto.board"/> (catalog-driven, currently
+    /// 32x48); it is not a client constant.
     /// </summary>
     public static class GameProtocol
     {
-        public const int BoardWidth = 72;
-        public const int BoardHeight = 60;
+        // Pre-connect fallback ONLY. The live board dimensions arrive with the
+        // first welcome/state broadcast (GameStateDto.board) and BoardManager
+        // builds its grid from those, not from these constants. Kept so any
+        // pre-connection UI has a sane default; do not treat as truth.
+        public const int BoardWidth = 32;
+        public const int BoardHeight = 48;
 
         public const string UnitArcher = "archer";
         public const string UnitWhelp = "whelp";
@@ -22,6 +29,12 @@ namespace BoardGame.Net
         public const string UnitBarracks = "barracks";
         public const string UnitCathedral = "cathedral";
 
+        /// <summary>
+        /// Fallback bounds check against the pre-connect default size. Once a
+        /// state broadcast has arrived, validate against the live board
+        /// dimensions instead (the server is the real authority — it rejects
+        /// out-of-bounds placements and simply sends no state change).
+        /// </summary>
         public static bool IsInBounds(int row, int col)
         {
             return row >= 0 && row < BoardWidth && col >= 0 && col < BoardHeight;

--- a/apps/game-client/wire-two-client-scene.py
+++ b/apps/game-client/wire-two-client-scene.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""
+Wire SampleScene for the two-client shared board (docs/two-client-shared-board-plan.md §3),
+deterministically and idempotently, without opening the Unity Editor.
+
+It performs the exact steps the manual Editor checklist describes:
+  1. Adds a scene-root GameObject "Net" with a GameServerClient component
+     (serverUrl ws://localhost:7777/ws, roomId lobby, playerName A, connectOnStart on).
+  2. Wires _BoardManager's `client` field to that GameServerClient, and assigns the
+     MineUnit / TheirsUnit materials to `mineMaterial` / `theirsMaterial`.
+  3. Registers the new Transform in SceneRoots so it shows up in the hierarchy.
+
+IMPORTANT: Close the Unity Editor before running this — the Editor holds the scene in
+memory and will overwrite on-disk edits on its next save. After running, reopen the
+project; Unity re-imports the scene and the wiring is already in place.
+
+Run:  python3 apps/game-client/wire-two-client-scene.py
+Safe to run twice: it detects prior wiring and refuses to duplicate.
+
+NOTE: playerName defaults to "A". For the SECOND client instance, change the running
+GameServerClient's Player Name to "B" in the Inspector (or duplicate with a distinct
+name). Two clients in the same room need DISTINCT player names.
+"""
+
+import sys
+from pathlib import Path
+
+SCENE = Path(__file__).parent / "Assets" / "Scenes" / "SampleScene.unity"
+
+# Fresh, collision-free fileIDs (highest existing object anchor was 2065756974).
+NET_GO = 2065756975
+NET_TRANSFORM = 2065756976
+NET_CLIENT = 2065756977
+
+# Component / asset GUIDs (from .meta files).
+GAMESERVERCLIENT_GUID = "2c3cee8b1a764f39b48b65ef8cefe87e"
+MINE_MAT_GUID = "6711111d9a5149618d1022910d0e3319"
+THEIRS_MAT_GUID = "530c9bfea0de4706ac0b20e2a4f337de"
+
+# The _BoardManager MonoBehaviour anchor (assigns the new fields onto it).
+BOARDMANAGER_MB = "&1541877564"
+
+NET_BLOCKS = f"""--- !u!1 &{NET_GO}
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {{fileID: 0}}
+  m_PrefabInstance: {{fileID: 0}}
+  m_PrefabAsset: {{fileID: 0}}
+  serializedVersion: 6
+  m_Component:
+  - component: {{fileID: {NET_TRANSFORM}}}
+  - component: {{fileID: {NET_CLIENT}}}
+  m_Layer: 0
+  m_Name: Net
+  m_TagString: Untagged
+  m_Icon: {{fileID: 0}}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &{NET_TRANSFORM}
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {{fileID: 0}}
+  m_PrefabInstance: {{fileID: 0}}
+  m_PrefabAsset: {{fileID: 0}}
+  m_GameObject: {{fileID: {NET_GO}}}
+  serializedVersion: 2
+  m_LocalRotation: {{x: 0, y: 0, z: 0, w: 1}}
+  m_LocalPosition: {{x: 0, y: 0, z: 0}}
+  m_LocalScale: {{x: 1, y: 1, z: 1}}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {{fileID: 0}}
+  m_LocalEulerAnglesHint: {{x: 0, y: 0, z: 0}}
+--- !u!114 &{NET_CLIENT}
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {{fileID: 0}}
+  m_PrefabInstance: {{fileID: 0}}
+  m_PrefabAsset: {{fileID: 0}}
+  m_GameObject: {{fileID: {NET_GO}}}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {{fileID: 11500000, guid: {GAMESERVERCLIENT_GUID}, type: 3}}
+  m_Name:
+  m_EditorClassIdentifier:
+  serverUrl: ws://localhost:7777/ws
+  roomId: lobby
+  playerName: A
+  connectOnStart: 1
+"""
+
+# Extra fields appended onto the _BoardManager MonoBehaviour block.
+BOARDMANAGER_FIELDS = f"""  client: {{fileID: {NET_CLIENT}}}
+  mineMaterial: {{fileID: 2100000, guid: {MINE_MAT_GUID}, type: 2}}
+  theirsMaterial: {{fileID: 2100000, guid: {THEIRS_MAT_GUID}, type: 2}}
+  mineColor: {{r: 0.2, g: 0.7, b: 0.65, a: 1}}
+  theirsColor: {{r: 0.8, g: 0.35, b: 0.2, a: 1}}
+"""
+
+
+def main() -> int:
+    text = SCENE.read_text()
+
+    if f"&{NET_CLIENT}" in text or "m_Name: Net\n" in text or "client: {fileID:" in text:
+        print("Scene already wired (found Net/GameServerClient or a client field). No change.")
+        return 0
+
+    lines = text.splitlines(keepends=True)
+
+    # 1. Append the new field lines onto the _BoardManager MonoBehaviour block.
+    #    The block starts at the line '--- !u!114 &1541877564' and ends at the
+    #    next '--- ' document separator. Insert our fields just before that.
+    bm_start = next(i for i, l in enumerate(lines) if l.startswith(f"--- !u!114 {BOARDMANAGER_MB}"))
+    bm_end = next(i for i in range(bm_start + 1, len(lines)) if lines[i].startswith("--- "))
+    lines.insert(bm_end, BOARDMANAGER_FIELDS)
+
+    text = "".join(lines)
+
+    # 2. Insert the Net GameObject/Transform/MonoBehaviour blocks before SceneRoots.
+    roots_marker = "--- !u!1660057539 &9223372036854775807\n"
+    if roots_marker not in text:
+        print("ERROR: SceneRoots block not found — scene structure changed. Aborting.", file=sys.stderr)
+        return 1
+    text = text.replace(roots_marker, NET_BLOCKS + roots_marker)
+
+    # 3. Register the Net Transform under SceneRoots m_Roots.
+    roots_anchor = "  m_Roots:\n"
+    idx = text.index(roots_marker)
+    roots_pos = text.index(roots_anchor, idx) + len(roots_anchor)
+    text = text[:roots_pos] + f"  - {{fileID: {NET_TRANSFORM}}}\n" + text[roots_pos:]
+
+    SCENE.write_text(text)
+    print("Wired SampleScene:")
+    print(f"  + Net GameObject (fileID {NET_GO}) with GameServerClient (ws://localhost:7777/ws, room lobby, name A)")
+    print(f"  + _BoardManager.client -> GameServerClient, mineMaterial/theirsMaterial assigned")
+    print(f"  + Net Transform registered in SceneRoots")
+    print("Reopen the project in Unity. For the 2nd client, set that instance's Player Name to 'B'.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/game-server/src/two-client-shared-board.test.ts
+++ b/apps/game-server/src/two-client-shared-board.test.ts
@@ -1,0 +1,243 @@
+import {
+	type ClientMessage,
+	type ServerMessage,
+	parseServerMessage,
+} from "@core/types";
+import { afterEach, describe, expect, test } from "bun:test";
+import { type GameServer, createGameServer } from "./server";
+
+/**
+ * Runtime verification of the TWO-CLIENT SHARED BOARD feature
+ * (docs/two-client-shared-board-plan.md §5) at the wire-protocol level.
+ *
+ * The Unity clients cannot be driven headlessly, but the whole point of the
+ * feature is that the board is a *view* of server-authoritative state: two
+ * clients in one room place units on one board, every placement is broadcast to
+ * everyone, ownership is carried by `ownerId`, and a departing player's units
+ * are pruned. This test exercises exactly that path with two real WebSocket
+ * clients against the real server, so each acceptance criterion the Unity
+ * BoardManager relies on is proven end-to-end here — everything except the
+ * pixels, which a human verifies by running two Editor instances (§4).
+ */
+
+const servers: GameServer[] = [];
+
+function startServer(): GameServer {
+	const gs = createGameServer({ port: 0 });
+	servers.push(gs);
+	return gs;
+}
+
+afterEach(() => {
+	for (const gs of servers.splice(0)) gs.stop();
+});
+
+/** Promise-based WebSocket client — the same shape a Unity GameServerClient drives. */
+class Client {
+	private readonly ws: WebSocket;
+	private readonly queue: ServerMessage[] = [];
+	private readonly waiters: Array<(m: ServerMessage) => void> = [];
+
+	private constructor(ws: WebSocket) {
+		this.ws = ws;
+		ws.onmessage = (event) => {
+			const parsed = parseServerMessage(String(event.data));
+			if (!parsed.ok)
+				throw new Error(`unparseable server message: ${parsed.error}`);
+			const waiter = this.waiters.shift();
+			if (waiter) waiter(parsed.message);
+			else this.queue.push(parsed.message);
+		};
+	}
+
+	static async connect(gs: GameServer): Promise<Client> {
+		const ws = new WebSocket(`ws://localhost:${gs.server.port}/ws`);
+		await new Promise<void>((resolve, reject) => {
+			ws.onopen = () => resolve();
+			ws.onerror = () => reject(new Error("failed to connect"));
+		});
+		return new Client(ws);
+	}
+
+	send(message: ClientMessage): void {
+		this.ws.send(JSON.stringify(message));
+	}
+
+	next(timeoutMs = 2000): Promise<ServerMessage> {
+		const queued = this.queue.shift();
+		if (queued) return Promise.resolve(queued);
+		return new Promise((resolve, reject) => {
+			const timer = setTimeout(
+				() => reject(new Error("timed out waiting for a server message")),
+				timeoutMs,
+			);
+			this.waiters.push((message) => {
+				clearTimeout(timer);
+				resolve(message);
+			});
+		});
+	}
+
+	/** Await the next `state` broadcast, skipping any interleaved messages. */
+	async nextState(timeoutMs = 2000): Promise<
+		Extract<ServerMessage, { type: "state" }>
+	> {
+		const deadline = Date.now() + timeoutMs;
+		for (;;) {
+			const remaining = Math.max(1, deadline - Date.now());
+			const message = await this.next(remaining);
+			if (message.type === "state") return message;
+		}
+	}
+
+	async expectNoMessage(windowMs = 150): Promise<void> {
+		await new Promise((resolve) => setTimeout(resolve, windowMs));
+		expect(this.queue).toHaveLength(0);
+	}
+
+	close(): void {
+		this.ws.close();
+	}
+}
+
+/** Join a room and return the client plus the playerId the server assigned. */
+async function join(
+	gs: GameServer,
+	roomId: string,
+	playerName: string,
+): Promise<{ client: Client; playerId: string }> {
+	const client = await Client.connect(gs);
+	client.send({ type: "join", roomId, playerName });
+	const welcome = await client.next();
+	if (welcome.type !== "welcome") {
+		throw new Error(`expected welcome, got ${welcome.type}`);
+	}
+	return { client, playerId: welcome.playerId };
+}
+
+describe("two-client shared board (acceptance criteria §5)", () => {
+	test("both clients join the same room and see the identical unit set", async () => {
+		const gs = startServer();
+
+		// A joins an empty room.
+		const a = await join(gs, "lobby", "A");
+		// B joins the same room; the join notifies A with a fresh state and B's
+		// own welcome carries the same authoritative state.
+		const b = await Client.connect(gs);
+		b.send({ type: "join", roomId: "lobby", playerName: "B" });
+
+		const bWelcome = await b.next();
+		if (bWelcome.type !== "welcome") {
+			throw new Error(`expected welcome for B, got ${bWelcome.type}`);
+		}
+		const aState = await a.client.nextState();
+
+		// A's broadcast and B's welcome describe the same board + players.
+		expect(aState.state.board).toEqual(bWelcome.state.board);
+		expect(aState.state.units).toEqual(bWelcome.state.units); // both empty, identically
+		expect(aState.state.players.map((p) => p.name).sort()).toEqual(["A", "B"]);
+
+		a.client.close();
+		b.close();
+	});
+
+	test("A places a unit → B receives it tinted as the opponent (correct ownerId), and vice versa", async () => {
+		const gs = startServer();
+		const a = await join(gs, "lobby", "A");
+		const b = await join(gs, "lobby", "B");
+		// Drain the join-notification state A received when B joined.
+		await a.client.nextState();
+
+		// A places a footman. Both clients get the broadcast.
+		a.client.send({ type: "placeUnit", unitType: "footman", row: 4, col: 4 });
+		const aSaw = await a.client.nextState();
+		const bSaw = await b.client.nextState();
+
+		// Same authoritative state on both screens — no divergence.
+		expect(aSaw.state.units).toEqual(bSaw.state.units);
+		expect(aSaw.state.units).toHaveLength(1);
+		const footman = aSaw.state.units[0];
+		expect(footman.unitType).toBe("footman");
+		// The unit is owned by A: A tints it "mine", B tints it "theirs".
+		expect(footman.ownerId).toBe(a.playerId);
+		expect(footman.ownerId).not.toBe(b.playerId);
+
+		// Now B places one somewhere non-overlapping; symmetric result.
+		b.client.send({ type: "placeUnit", unitType: "archer", row: 10, col: 40 });
+		const aSaw2 = await a.client.nextState();
+		const bSaw2 = await b.client.nextState();
+		expect(aSaw2.state.units).toEqual(bSaw2.state.units);
+		expect(aSaw2.state.units).toHaveLength(2);
+		const archer = aSaw2.state.units.find((u) => u.unitType === "archer");
+		expect(archer?.ownerId).toBe(b.playerId);
+
+		a.client.close();
+		b.client.close();
+	});
+
+	test("the placer's unit appears only after the server confirms (no pre-spawn), and a rejected placement changes nothing on either client", async () => {
+		const gs = startServer();
+		const a = await join(gs, "lobby", "A");
+		const b = await join(gs, "lobby", "B");
+		await a.client.nextState(); // drain B's join notification
+
+		// Valid placement: the unit exists only once the broadcast arrives. The
+		// server assigns the id (BoardManager keys its render diff off it), so
+		// there is nothing the client could have spawned ahead of this.
+		a.client.send({ type: "placeUnit", unitType: "footman", row: 4, col: 4 });
+		const confirmed = await a.client.nextState();
+		expect(confirmed.state.units).toHaveLength(1);
+		expect(confirmed.state.units[0].id).toBeTruthy();
+		await b.client.nextState(); // B also gets it
+
+		// Rejected placement: overlap the just-placed footman's footprint.
+		a.client.send({ type: "placeUnit", unitType: "footman", row: 4, col: 4 });
+		const rejection = await a.client.next();
+		expect(rejection.type).toBe("error");
+		if (rejection.type === "error") {
+			expect(rejection.code).toBe("tileOccupied");
+		}
+		// No state change reaches anyone — the board is unchanged on both screens.
+		await a.client.expectNoMessage();
+		await b.client.expectNoMessage();
+
+		// Off the catalog board (32x48) but within the wire schema's coordinate
+		// range: the frame parses, then the Room rejects it as out-of-bounds.
+		// (BoardManager can't even produce such a click — it builds its grid from
+		// the 32x48 the server reports — but the server enforces it regardless.)
+		a.client.send({ type: "placeUnit", unitType: "footman", row: 30, col: 47 });
+		const oob = await a.client.next();
+		expect(oob.type).toBe("error");
+		if (oob.type === "error") expect(oob.code).toBe("outOfBounds");
+		await a.client.expectNoMessage();
+		await b.client.expectNoMessage();
+
+		a.client.close();
+		b.client.close();
+	});
+
+	test("disconnecting one client removes its units from the other's board", async () => {
+		const gs = startServer();
+		const a = await join(gs, "lobby", "A");
+		const b = await join(gs, "lobby", "B");
+		await a.client.nextState(); // drain B's join notification
+
+		// A and B each place a unit.
+		a.client.send({ type: "placeUnit", unitType: "footman", row: 4, col: 4 });
+		await a.client.nextState();
+		await b.client.nextState();
+		b.client.send({ type: "placeUnit", unitType: "archer", row: 10, col: 40 });
+		await a.client.nextState();
+		const beforeLeave = await b.client.nextState();
+		expect(beforeLeave.state.units).toHaveLength(2);
+
+		// A leaves. The server prunes A's units and broadcasts to B.
+		a.client.close();
+		const afterLeave = await b.client.nextState();
+		expect(afterLeave.state.units).toHaveLength(1);
+		expect(afterLeave.state.units[0].ownerId).toBe(b.playerId);
+		expect(afterLeave.state.players.map((p) => p.name)).toEqual(["B"]);
+
+		b.client.close();
+	});
+});

--- a/apps/game-server/src/two-client-shared-board.test.ts
+++ b/apps/game-server/src/two-client-shared-board.test.ts
@@ -79,9 +79,9 @@ class Client {
 	}
 
 	/** Await the next `state` broadcast, skipping any interleaved messages. */
-	async nextState(timeoutMs = 2000): Promise<
-		Extract<ServerMessage, { type: "state" }>
-	> {
+	async nextState(
+		timeoutMs = 2000,
+	): Promise<Extract<ServerMessage, { type: "state" }>> {
 		const deadline = Date.now() + timeoutMs;
 		for (;;) {
 			const remaining = Math.max(1, deadline - Date.now());

--- a/docs/two-client-shared-board-plan.html
+++ b/docs/two-client-shared-board-plan.html
@@ -1,0 +1,555 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Shared Board — Two-Client Placement Plan</title>
+<style>
+  :root {
+    /* neutrals biased cool-slate toward the accent */
+    --paper: #f6f7f9;
+    --surface: #ffffff;
+    --surface-2: #eef1f5;
+    --ink: #161b23;
+    --ink-2: #414a58;
+    --ink-3: #6b7585;
+    --line: #dde2e9;
+    --line-strong: #c7ceda;
+
+    /* one accent = "the server / authority" */
+    --accent: #2f5fe0;
+    --accent-soft: #e7edfc;
+
+    /* content colors — the ownership coding the plan is about */
+    --mine: #1f8f6a;
+    --mine-soft: #e0f2ea;
+    --theirs: #c14a34;
+    --theirs-soft: #f9e6e1;
+
+    /* semantic status (separate from accent) */
+    --ok: #1f8f6a;
+    --warn: #b8791b;
+    --none: #6b7585;
+
+    --shadow: 0 1px 2px rgba(20, 27, 35, .04), 0 8px 24px rgba(20, 27, 35, .05);
+
+    --measure: 44rem;
+    --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    --mono: ui-monospace, "SF Mono", "JetBrains Mono", "Cascadia Mono", Menlo, Consolas, monospace;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --paper: #0f1319;
+      --surface: #151b24;
+      --surface-2: #1b232e;
+      --ink: #e8ecf2;
+      --ink-2: #b3bcca;
+      --ink-3: #7f8b9d;
+      --line: #26303c;
+      --line-strong: #313d4c;
+      --accent: #7aa0ff;
+      --accent-soft: #1a2740;
+      --mine: #46c396;
+      --mine-soft: #133026;
+      --theirs: #e6795f;
+      --theirs-soft: #34201b;
+      --ok: #46c396;
+      --warn: #d6a24a;
+      --none: #7f8b9d;
+      --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+    }
+  }
+  /* viewer toggle must win in both directions */
+  :root[data-theme="light"] {
+    --paper: #f6f7f9; --surface: #fff; --surface-2: #eef1f5;
+    --ink: #161b23; --ink-2: #414a58; --ink-3: #6b7585;
+    --line: #dde2e9; --line-strong: #c7ceda;
+    --accent: #2f5fe0; --accent-soft: #e7edfc;
+    --mine: #1f8f6a; --mine-soft: #e0f2ea; --theirs: #c14a34; --theirs-soft: #f9e6e1;
+    --ok: #1f8f6a; --warn: #b8791b; --none: #6b7585;
+    --shadow: 0 1px 2px rgba(20,27,35,.04), 0 8px 24px rgba(20,27,35,.05);
+  }
+  :root[data-theme="dark"] {
+    --paper: #0f1319; --surface: #151b24; --surface-2: #1b232e;
+    --ink: #e8ecf2; --ink-2: #b3bcca; --ink-3: #7f8b9d;
+    --line: #26303c; --line-strong: #313d4c;
+    --accent: #7aa0ff; --accent-soft: #1a2740;
+    --mine: #46c396; --mine-soft: #133026; --theirs: #e6795f; --theirs-soft: #34201b;
+    --ok: #46c396; --warn: #d6a24a; --none: #7f8b9d;
+    --shadow: 0 1px 2px rgba(0,0,0,.3), 0 10px 30px rgba(0,0,0,.35);
+  }
+
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0;
+    background: var(--paper);
+    color: var(--ink);
+    font-family: var(--sans);
+    font-size: 17px;
+    line-height: 1.65;
+    -webkit-font-smoothing: antialiased;
+    text-rendering: optimizeLegibility;
+  }
+
+  .wrap { max-width: var(--measure); margin: 0 auto; padding: 0 1.5rem; }
+
+  /* ---- header ---- */
+  header {
+    position: relative;
+    border-bottom: 1px solid var(--line);
+    background:
+      linear-gradient(var(--surface), var(--surface));
+    overflow: hidden;
+  }
+  header::before {
+    content: "";
+    position: absolute; inset: 0;
+    background-image:
+      linear-gradient(to right, var(--line) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--line) 1px, transparent 1px);
+    background-size: 26px 26px;
+    opacity: .5;
+    -webkit-mask-image: radial-gradient(120% 90% at 82% 0%, #000 0%, transparent 72%);
+            mask-image: radial-gradient(120% 90% at 82% 0%, #000 0%, transparent 72%);
+    pointer-events: none;
+  }
+  .header-inner { position: relative; padding: 3.2rem 0 2.6rem; }
+  .eyebrow {
+    font-family: var(--mono);
+    font-size: .72rem;
+    letter-spacing: .16em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin: 0 0 1rem;
+    display: flex; align-items: center; gap: .6rem;
+  }
+  .eyebrow .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); box-shadow: 0 0 0 4px var(--accent-soft); }
+  h1 {
+    font-family: var(--sans);
+    font-weight: 760;
+    letter-spacing: -.024em;
+    line-height: 1.04;
+    text-wrap: balance;
+    font-size: clamp(2.1rem, 6vw, 3.15rem);
+    margin: 0 0 .9rem;
+  }
+  .lede {
+    font-size: 1.14rem;
+    color: var(--ink-2);
+    max-width: 38rem;
+    margin: 0 0 1.6rem;
+    text-wrap: pretty;
+  }
+  .meta {
+    display: flex; flex-wrap: wrap; gap: .5rem;
+    font-family: var(--mono); font-size: .78rem;
+  }
+  .tag {
+    display: inline-flex; align-items: center; gap: .45rem;
+    padding: .32rem .7rem;
+    border: 1px solid var(--line-strong);
+    border-radius: 999px;
+    color: var(--ink-2);
+    background: var(--surface);
+  }
+  .tag b { color: var(--ink); font-weight: 600; }
+  .swatch { width: 9px; height: 9px; border-radius: 2px; }
+  .sw-mine { background: var(--mine); }
+  .sw-theirs { background: var(--theirs); }
+  .sw-server { background: var(--accent); }
+
+  /* ---- sections ---- */
+  main { padding: 3rem 0 4rem; }
+  section { margin-bottom: 3.2rem; }
+  .section-label {
+    font-family: var(--mono);
+    font-size: .72rem; letter-spacing: .16em; text-transform: uppercase;
+    color: var(--ink-3);
+    display: flex; align-items: center; gap: .8rem;
+    margin: 0 0 1.1rem;
+  }
+  .section-label::after { content: ""; flex: 1; height: 1px; background: var(--line); }
+  h2 {
+    font-weight: 720; letter-spacing: -.018em; line-height: 1.12;
+    font-size: 1.6rem; margin: 0 0 .8rem; text-wrap: balance;
+  }
+  h3 { font-weight: 660; font-size: 1.06rem; letter-spacing: -.01em; margin: 1.8rem 0 .5rem; }
+  p { margin: 0 0 1rem; color: var(--ink-2); }
+  p strong, li strong { color: var(--ink); font-weight: 640; }
+  .measure p, .measure li { max-width: 40rem; }
+  a { color: var(--accent); text-decoration: none; border-bottom: 1px solid color-mix(in srgb, var(--accent) 35%, transparent); }
+  a:hover { border-bottom-color: var(--accent); }
+  code {
+    font-family: var(--mono); font-size: .86em;
+    background: var(--surface-2); color: var(--ink);
+    padding: .1em .38em; border-radius: 5px;
+    border: 1px solid var(--line);
+  }
+
+  /* the one-line thesis callout */
+  .thesis {
+    border: 1px solid var(--line);
+    border-left: 3px solid var(--accent);
+    background: var(--surface);
+    border-radius: 10px;
+    padding: 1.15rem 1.3rem;
+    box-shadow: var(--shadow);
+  }
+  .thesis p { margin: 0; color: var(--ink); font-size: 1.05rem; }
+  .thesis .k { color: var(--accent); font-weight: 640; }
+
+  /* ---- dataflow diagram ---- */
+  .flow {
+    border: 1px solid var(--line);
+    background: var(--surface);
+    border-radius: 14px;
+    padding: 1.6rem 1.3rem;
+    box-shadow: var(--shadow);
+  }
+  .flow-caption { font-family: var(--mono); font-size: .72rem; letter-spacing: .12em; text-transform: uppercase; color: var(--ink-3); margin: 0 0 1.4rem; }
+  .rail {
+    display: grid;
+    grid-template-columns: 1fr auto 1.15fr auto 1fr;
+    align-items: center;
+    gap: .5rem;
+  }
+  .node {
+    border-radius: 12px;
+    padding: .95rem .8rem;
+    text-align: center;
+    border: 1.5px solid;
+    background: var(--surface);
+  }
+  .node .role { font-family: var(--mono); font-size: .66rem; letter-spacing: .12em; text-transform: uppercase; margin: 0 0 .35rem; }
+  .node .name { font-weight: 680; font-size: .98rem; letter-spacing: -.01em; }
+  .node .sub { font-size: .78rem; color: var(--ink-3); margin-top: .2rem; }
+  .node.mine { border-color: var(--mine); background: var(--mine-soft); }
+  .node.mine .role { color: var(--mine); }
+  .node.theirs { border-color: var(--theirs); background: var(--theirs-soft); }
+  .node.theirs .role { color: var(--theirs); }
+  .node.server { border-color: var(--accent); background: var(--accent-soft); }
+  .node.server .role { color: var(--accent); }
+
+  .arrow { display: flex; flex-direction: column; align-items: center; gap: .25rem; min-width: 58px; }
+  .arrow .line { position: relative; width: 100%; height: 2px; background: var(--line-strong); }
+  .arrow .line::after {
+    content: ""; position: absolute; right: -1px; top: 50%; transform: translateY(-50%);
+    border-left: 6px solid var(--line-strong);
+    border-top: 4px solid transparent; border-bottom: 4px solid transparent;
+  }
+  .arrow.back .line::after { right: auto; left: -1px; border-left: 0; border-right: 6px solid var(--accent); border-color: transparent; border-right-color: var(--accent); }
+  .arrow.back .line { background: var(--accent); }
+  .arrow.fwd .line { background: var(--accent); }
+  .arrow.fwd .line::after { border-left-color: var(--accent); }
+  .arrow .lbl { font-family: var(--mono); font-size: .64rem; letter-spacing: .04em; color: var(--ink-3); text-align: center; line-height: 1.25; }
+  .flow-note { margin: 1.35rem 0 0; font-size: .88rem; color: var(--ink-3); }
+  .flow-note b { color: var(--accent); font-weight: 620; }
+
+  /* before / after */
+  .ba { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+  .ba .card { border: 1px solid var(--line); border-radius: 12px; background: var(--surface); padding: 1.2rem; box-shadow: var(--shadow); }
+  .ba .card h4 { margin: 0 0 .7rem; font-size: .82rem; font-family: var(--mono); letter-spacing: .1em; text-transform: uppercase; display: flex; align-items: center; gap: .5rem; }
+  .ba .before h4 { color: var(--theirs); }
+  .ba .after h4 { color: var(--mine); }
+  .ba .card p { margin: 0; font-size: .95rem; color: var(--ink-2); }
+  .ba .flowline { font-family: var(--mono); font-size: .82rem; color: var(--ink); margin-top: .7rem; line-height: 1.7; }
+  .ba .flowline .x { color: var(--theirs); }
+  .ba .flowline .ok { color: var(--mine); }
+
+  /* work table */
+  .table-scroll { overflow-x: auto; border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--shadow); }
+  table { width: 100%; border-collapse: collapse; font-size: .93rem; min-width: 34rem; background: var(--surface); }
+  thead th {
+    text-align: left; font-family: var(--mono); font-size: .68rem; letter-spacing: .1em; text-transform: uppercase;
+    color: var(--ink-3); font-weight: 600; padding: .85rem 1rem; border-bottom: 1px solid var(--line-strong); background: var(--surface-2);
+  }
+  tbody td { padding: .8rem 1rem; border-bottom: 1px solid var(--line); color: var(--ink-2); vertical-align: top; }
+  tbody tr:last-child td { border-bottom: 0; }
+  td .what { color: var(--ink); font-weight: 600; display: block; margin-bottom: .15rem; }
+  td code { font-size: .82em; }
+  .owner { display: inline-flex; align-items: center; gap: .4rem; font-family: var(--mono); font-size: .74rem; padding: .22rem .55rem; border-radius: 6px; white-space: nowrap; }
+  .owner.me { color: var(--accent); background: var(--accent-soft); }
+  .owner.none { color: var(--none); background: var(--surface-2); }
+
+  /* status pill */
+  .pill { display: inline-flex; align-items: center; gap: .4rem; font-family: var(--mono); font-size: .72rem; padding: .24rem .6rem; border-radius: 999px; white-space: nowrap; }
+  .pill::before { content: ""; width: 7px; height: 7px; border-radius: 50%; }
+  .pill.done { color: var(--ok); background: color-mix(in srgb, var(--ok) 12%, transparent); }
+  .pill.done::before { background: var(--ok); }
+  .pill.build { color: var(--warn); background: color-mix(in srgb, var(--warn) 14%, transparent); }
+  .pill.build::before { background: var(--warn); }
+  .pill.human { color: var(--accent); background: var(--accent-soft); }
+  .pill.human::before { background: var(--accent); }
+
+  /* checklist */
+  .checklist { list-style: none; padding: 0; margin: 0; counter-reset: step; display: flex; flex-direction: column; gap: .55rem; }
+  .checklist li {
+    position: relative; counter-increment: step;
+    background: var(--surface); border: 1px solid var(--line); border-radius: 10px;
+    padding: .85rem 1rem .85rem 3.1rem; color: var(--ink-2); font-size: .95rem;
+  }
+  .checklist li::before {
+    content: counter(step); position: absolute; left: .8rem; top: .78rem;
+    width: 1.55rem; height: 1.55rem; border-radius: 7px;
+    background: var(--accent-soft); color: var(--accent);
+    font-family: var(--mono); font-size: .8rem; font-weight: 700;
+    display: grid; place-items: center;
+  }
+  .checklist li b { color: var(--ink); }
+
+  /* acceptance / cards grid */
+  .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(15rem, 1fr)); gap: .9rem; }
+  .accept { border: 1px solid var(--line); border-radius: 11px; background: var(--surface); padding: 1rem 1.1rem; box-shadow: var(--shadow); }
+  .accept .head { display: flex; align-items: center; gap: .55rem; font-weight: 640; color: var(--ink); font-size: .96rem; margin-bottom: .3rem; }
+  .accept .head .chk { flex: none; width: 20px; height: 20px; border-radius: 50%; background: var(--mine-soft); color: var(--mine); display: grid; place-items: center; font-size: .72rem; font-weight: 800; }
+  .accept p { margin: 0; font-size: .88rem; color: var(--ink-3); }
+
+  ul.clean { padding-left: 1.15rem; margin: 0 0 1rem; }
+  ul.clean li { margin-bottom: .5rem; color: var(--ink-2); }
+
+  .run { background: var(--ink); color: var(--paper); border-radius: 12px; padding: 1.1rem 1.2rem; font-family: var(--mono); font-size: .86rem; overflow-x: auto; }
+  :root[data-theme="dark"] .run, :root[data-theme="light"] .run { }
+  .run .c { color: var(--ink-3); }
+  .run .p { color: #7aa0ff; }
+
+  footer { border-top: 1px solid var(--line); padding: 2rem 0 3rem; color: var(--ink-3); font-size: .84rem; }
+  footer .wrap { display: flex; flex-wrap: wrap; gap: .5rem 1.4rem; align-items: center; justify-content: space-between; }
+  footer code { background: transparent; border: 0; padding: 0; color: var(--ink-2); }
+
+  @media (max-width: 620px) {
+    .rail { grid-template-columns: 1fr; }
+    .arrow { flex-direction: row; min-height: 44px; min-width: 0; justify-content: center; }
+    .arrow .line { width: 2px; height: 34px; }
+    .arrow .line::after { right: 50%; top: auto; bottom: -1px; transform: translateX(50%); border-left: 4px solid transparent; border-right: 4px solid transparent; border-top: 6px solid var(--line-strong); border-bottom: 0; }
+    .ba { grid-template-columns: 1fr; }
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .node { transition: transform .15s ease; }
+  }
+</style>
+</head>
+<body>
+
+<header>
+  <div class="wrap header-inner">
+    <p class="eyebrow"><span class="dot"></span> Implementation Plan · Multiplayer</p>
+    <h1>One board, two clients, placing units live.</h1>
+    <p class="lede">Turning the local placement demo into a shared, server-authoritative board — where each player watches the other deploy in real time, color-coded by owner.</p>
+    <div class="meta">
+      <span class="tag"><b>Server</b> v1 game-server</span>
+      <span class="tag"><span class="swatch sw-mine"></span> your units</span>
+      <span class="tag"><span class="swatch sw-theirs"></span> opponent</span>
+      <span class="tag"><span class="swatch sw-server"></span> authority</span>
+      <span class="tag"><b>Board</b> 32 × 48</span>
+    </div>
+  </div>
+</header>
+
+<main class="wrap measure">
+
+  <!-- THESIS -->
+  <section>
+    <p class="section-label">The short version</p>
+    <div class="thesis">
+      <p>This is <span class="k">almost entirely a client-side change.</span> The server already runs an authoritative multiplayer board and broadcasts every placement to the whole room. The one missing half is that the Unity client places units <em>locally</em> and never talks to the network.</p>
+    </div>
+  </section>
+
+  <!-- WHY -->
+  <section>
+    <p class="section-label">Why it's mostly done already</p>
+    <h2>The server is ready; the client is disconnected.</h2>
+    <p>Two sockets in the same room already share one validated board. What's missing is the wire between the click and the server, and rendering what the server reports back.</p>
+
+    <div class="cards" style="margin-top:1.2rem">
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Server</div>
+        <p>Each socket gets a unique owner id. Placements are validated (footprint, bounds, overlap) and every valid move broadcasts fresh state to the room. No changes needed.</p>
+      </div>
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Network client</div>
+        <p><code>GameServerClient.cs</code> already sends <code>placeUnit</code> and receives <code>state</code> — but it isn't in the scene and nothing references it.</p>
+      </div>
+      <div class="accept">
+        <div class="head" style="color:var(--theirs)"><span class="chk" style="background:var(--theirs-soft);color:var(--theirs)">×</span> Board manager</div>
+        <p><code>BoardManager.cs</code> is 100% local: a click spawns a model on the spot. It never asks the server and never renders remote units.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- FLOW -->
+  <section>
+    <p class="section-label">Target architecture</p>
+    <h2>The board becomes a view of server state.</h2>
+    <p>A click no longer spawns anything directly. It asks the server, the server validates and broadcasts, and <strong>every</strong> client — including the one who clicked — rebuilds its units from that broadcast.</p>
+
+    <div class="flow" style="margin-top:1.3rem">
+      <p class="flow-caption">// Client A places a unit</p>
+      <div class="rail">
+        <div class="node mine">
+          <p class="role">Client A · you</p>
+          <div class="name">Places Footman</div>
+          <div class="sub">click → request</div>
+        </div>
+        <div class="arrow fwd">
+          <span class="lbl">placeUnit<br>(type, row, col)</span>
+          <span class="line"></span>
+        </div>
+        <div class="node server">
+          <p class="role">Server · authority</p>
+          <div class="name">Validate &amp; store</div>
+          <div class="sub">footprint · bounds · overlap</div>
+        </div>
+        <div class="arrow back">
+          <span class="lbl">state<br>(broadcast)</span>
+          <span class="line"></span>
+        </div>
+        <div class="node theirs">
+          <p class="role">Client B · opponent</p>
+          <div class="name">Renders Footman</div>
+          <div class="sub">owner-colored</div>
+        </div>
+      </div>
+      <p class="flow-note"><b>Both</b> clients receive the same <code>state</code> and reconcile — the placer sees its own unit only once the server confirms it, so the two screens can never disagree.</p>
+    </div>
+  </section>
+
+  <!-- BEFORE / AFTER -->
+  <section>
+    <p class="section-label">The core shift</p>
+    <div class="ba">
+      <div class="card before">
+        <h4>Today — local</h4>
+        <p>Placement mode spawns a model immediately on the clicked tile. State lives only in that one client.</p>
+        <p class="flowline">click <span class="x">→ spawn model</span></p>
+      </div>
+      <div class="card after">
+        <h4>Target — authoritative</h4>
+        <p>Placement routes through the server; every client re-renders from the broadcast. One shared truth.</p>
+        <p class="flowline">click <span class="ok">→ ask server → render state</span></p>
+      </div>
+    </div>
+  </section>
+
+  <!-- WORK -->
+  <section>
+    <p class="section-label">Work breakdown</p>
+    <h2>Three files change. The server doesn't.</h2>
+    <div class="table-scroll">
+      <table>
+        <thead>
+          <tr><th>Change</th><th>Detail</th><th>Owner</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><span class="what">BoardManager.cs</span><span style="font-size:.8rem;color:var(--ink-3)">the real rewrite</span></td>
+            <td>Route clicks through <code>SendPlaceUnit</code> (no local spawn). Add a diff-based <code>RenderState</code> that spawns/removes units by id and colors them by owner. Build the tile grid from the server's <code>32×48</code>, not the hardcoded 32×32.</td>
+            <td><span class="owner me">Claude</span></td>
+          </tr>
+          <tr>
+            <td><span class="what">GameProtocol.cs</span><span style="font-size:.8rem;color:var(--ink-3)">board constants</span></td>
+            <td>Trust the board size the server sends in <code>welcome</code> / <code>state</code> instead of the stale <code>72×60</code> constants.</td>
+            <td><span class="owner me">Claude</span></td>
+          </tr>
+          <tr>
+            <td><span class="what">GameServerClient.cs</span><span style="font-size:.8rem;color:var(--ink-3)">small additions</span></td>
+            <td>Room / player-name setters so two instances share a room with distinct names; surface <code>error</code> feedback when the server rejects a placement.</td>
+            <td><span class="owner me">Claude</span></td>
+          </tr>
+          <tr>
+            <td><span class="what">apps/game-server</span><span style="font-size:.8rem;color:var(--ink-3)">no change</span></td>
+            <td>Already validates and broadcasts. Two clients in one room already share state today.</td>
+            <td><span class="owner none">—</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- RECONCILE -->
+  <section>
+    <p class="section-label">Three things to reconcile</p>
+    <ul class="clean">
+      <li><strong>Board size.</strong> The client hardcodes 32×32; the server's catalog board is 32×48. Build the grid from server dimensions so no placement lands on a tile that doesn't exist.</li>
+      <li><strong>Ownership.</strong> The client always places as "Player 1." In the shared model, <em>your</em> units are whatever the server tags with <em>your</em> id; everything else is the opponent's. Color follows from that.</li>
+      <li><strong>Coordinates.</strong> Protocol <code>row</code> = world-X (wide), <code>col</code> = world-Z (deep). Keep tile mapping consistent with the server so a unit lands where it was clicked on both screens.</li>
+    </ul>
+  </section>
+
+  <!-- EDITOR STEPS -->
+  <section>
+    <p class="section-label">Editor wiring · your checklist</p>
+    <h2>The click-only steps.</h2>
+    <p>All C# is written for you. These are the Unity Editor actions that can't be scripted:</p>
+    <ol class="checklist">
+      <li>Open <b>Assets/Scenes/SampleScene.unity</b>.</li>
+      <li>Create an empty GameObject <b>Net</b> → Add Component → <b>GameServerClient</b>.</li>
+      <li>Set <code>serverUrl = ws://localhost:7777/ws</code>, <code>roomId = lobby</code>, and a distinct <b>playerName</b> per instance.</li>
+      <li>Select <b>_BoardManager</b> and drag <b>Net</b> into its new <b>Client</b> slot.</li>
+      <li>Assign the two owner colors — <b>Mine</b> and <b>Theirs</b> — on _BoardManager.</li>
+      <li>Run two clients on the same room and place units.</li>
+    </ol>
+  </section>
+
+  <!-- RUN -->
+  <section>
+    <p class="section-label">Running two clients</p>
+    <p>Start the server first, then run two instances against the same room. Simplest is the Editor plus one standalone build; Multiplayer Play Mode (already in the project) is the zero-build option.</p>
+    <div class="run">
+      <span class="c"># start the authoritative server</span><br>
+      cd apps/game-server &amp;&amp; <span class="p">bun run dev</span>&nbsp;&nbsp;<span class="c"># ws://localhost:7777/ws</span>
+    </div>
+  </section>
+
+  <!-- ACCEPTANCE -->
+  <section>
+    <p class="section-label">Done when</p>
+    <h2>What "working" looks like.</h2>
+    <div class="cards" style="margin-top:1.1rem">
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Shared view</div>
+        <p>Two clients join <code>lobby</code> and see the exact same set of units.</p>
+      </div>
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Live placement</div>
+        <p>A places a Footman → within a frame, B sees it appear, opponent-colored. And the reverse.</p>
+      </div>
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Rejections hold</div>
+        <p>An occupied or out-of-bounds placement appears on neither client; the placer gets feedback.</p>
+      </div>
+      <div class="accept">
+        <div class="head"><span class="chk">✓</span> Clean disconnect</div>
+        <p>When one client leaves, its units disappear from the other's board.</p>
+      </div>
+    </div>
+  </section>
+
+  <!-- SCOPE NOTE -->
+  <section>
+    <p class="section-label">Scope, deliberately</p>
+    <p>This uses the <strong>v1 protocol</strong>: no commanders, economy, or battles, and placement is open anywhere on the board — no half-restriction. That's the fastest path to "two clients, one board," and exactly the feature requested. The full match loop (hidden planning, commander pick, simulated battles) already exists server-side and is a separate, larger effort to wire into the client.</p>
+  </section>
+
+</main>
+
+<footer>
+  <div class="wrap">
+    <span>Shared-board multiplayer · implementation plan</span>
+    <span><code>docs/two-client-shared-board-plan.md</code> · full detail</span>
+  </div>
+</footer>
+
+<script>
+  // Keep the viewer's saved theme choice authoritative if one was stamped.
+  (function () {
+    try {
+      var t = localStorage.getItem("theme");
+      if (t === "dark" || t === "light") document.documentElement.setAttribute("data-theme", t);
+    } catch (e) {}
+  })();
+</script>
+</body>
+</html>

--- a/docs/two-client-shared-board-plan.md
+++ b/docs/two-client-shared-board-plan.md
@@ -1,0 +1,295 @@
+# Implementation Plan — Two Clients Placing Units on One Shared Board
+
+Status: ready to build. Detailed, execution-ready plan.
+
+**Goal.** Two Unity clients connected to the same room see and place units on one
+shared, **server-authoritative** board. Every client renders every unit,
+color-coded by owner; placements appear live on both screens; the server is the
+single source of truth.
+
+**Decisions (locked):**
+1. Server = **v1 `apps/game-server`** (simple `placeUnit`/`moveUnit` protocol).
+2. Ownership = **open + color-coded** (both see all units; no hidden info, no
+   own-half restriction).
+3. Editor work = **guided**; all C# written here, user does a short click-list.
+
+---
+
+## 0. Ground truth (verified against the code)
+
+| Fact | Detail | Source |
+|---|---|---|
+| Server is already multiplayer | Each socket → unique `playerId` (`crypto.randomUUID()`) used as `ownerId`. Valid `placeUnit`/`moveUnit` → `broadcastState(roomId)` to the `room:<id>` topic. | `apps/game-server/src/server.ts`, `room.ts` |
+| Server board is catalog-driven | `getState().board = { width: catalog.board.w, height: catalog.board.h }` = **32 × 48**. Placement validated for footprint, bounds, multi-tile overlap. | `room.ts:132` |
+| `unitType` is any catalog id | Server validates `unitType` against the loaded catalog, not a fixed enum. | `room.ts:72` |
+| Client net layer exists, unused | `GameServerClient.cs` connects, sends `join`/`placeUnit`/`moveUnit`, raises `WelcomeReceived`/`StateReceived`/`ErrorReceived` on the main thread. **Not in the scene; referenced by nothing.** | `Net/GameServerClient.cs` |
+| Client DTOs exist | `GameStateDto{ board, players[], units[] }`, `UnitDto{ id, ownerId, unitType, row, col }`, `WelcomeMessage{ playerId, roomId, state }`, `StateMessage{ state }`, `ErrorMessage{ code, message }`. | `Net/GameProtocol.cs` |
+| Board manager is fully local | `PlaceUnit(IUnitDetails, Player, x, y)` spawns models immediately; own occupancy array; placement modes place only as `Player.Player1`. Hardcoded `BOARD_WIDTH=BOARD_HEIGHT=32`. | `BoardManager.cs` |
+| Scene UI depends on toggle names | `FootmanButton/ArcherButton/WhelpButton` + a HolyKnight button are wired to `Toggle{Footman,Archer,Whelp,HolyKnight}PlacementMode()` — **these method names must survive.** | `SampleScene.unity` |
+| Unit visual contract | `IUnitDetails{ UnitName, ModelPrefab, ModelPositionOffset, ModelRotation, ModelHeight, FootprintSize, GetSquadFormation() }`; 6 `*Details` ScriptableObjects exist. | `IUnitDetails.cs`, `BaseUnitDetails.cs` |
+
+**Consequence:** the server needs **no changes**. All work is in three client
+files plus scene wiring.
+
+---
+
+## 1. Architecture: the board is a *view* of server state
+
+```
+ placement-mode click on a tile
+        │  (NO local spawn anymore)
+        ▼
+ BoardManager.RequestPlace(unitType, row, col)
+        └─► client.SendPlaceUnit(unitType, row, col) ──► v1 server
+                                                          validate → store
+                                                          broadcast `state`
+        ┌──────────────────────────────────────────────────┘
+        ▼  to EVERY socket in the room (incl. the placer)
+ GameServerClient.StateReceived(GameStateDto)
+        └─► BoardManager.RenderState(state)   // diff by unit.id → spawn/despawn
+```
+
+Two invariants this buys us:
+- **No divergence.** Neither client mutates its board directly; both mirror the
+  same broadcast. Two screens can't disagree.
+- **Server rejections are automatic.** If the server refuses (occupied / bounds),
+  no `state` change arrives, so nothing renders. An `error` gives feedback.
+
+---
+
+## 2. File-by-file work
+
+### 2.1 `GameProtocol.cs` — trust the server's board size
+
+**Problem.** Constants say `72×60`; server says `32×48`; `BoardManager` uses
+`32×32`. Three disagreeing numbers.
+
+**Change.** Demote the constants to a *fallback only* and stop treating them as
+truth. Concretely:
+- Keep `BoardWidth`/`BoardHeight` but rename intent in a comment to
+  "pre-connect fallback"; the live board comes from `GameStateDto.board`.
+- Leave `IsInBounds` as-is (only used, if at all, before a state arrives).
+- No DTO changes needed — `BoardDto{width,height}` already carries the real size.
+
+*Risk:* none. Purely a semantics/comment change; the client already reads
+`state.board`.
+
+### 2.2 `GameServerClient.cs` — make it configurable + expose errors
+
+Small, additive changes so two instances can share a room with distinct names
+and so BoardManager can show rejection feedback.
+
+- Add public setters/inspector fields already exist (`serverUrl`, `roomId`,
+  `playerName`, `connectOnStart`) — **no change needed** for config; they're
+  `[SerializeField]` and set per-instance in the Editor.
+- `ErrorReceived` event **already exists** — BoardManager just needs to
+  subscribe. No client change required.
+- **Optional nicety:** add a `public string PlayerName { get => playerName; set => playerName = value; }`
+  and `public string RoomId { … }` so two virtual players (MPPM) can be told
+  apart at runtime without separate scenes. Only needed if using MPPM; skip for
+  the Editor+build path.
+
+*Net:* `GameServerClient.cs` likely needs **zero** changes for the core feature.
+Its API is already sufficient.
+
+### 2.3 `BoardManager.cs` — the real rewrite
+
+This is 90% of the work. Rewrite around a diff-based renderer. Keep the public
+`Toggle*PlacementMode()` methods (scene buttons depend on them).
+
+**New/changed fields:**
+```csharp
+[SerializeField] private BoardGame.Net.GameServerClient client; // assigned in Editor
+[SerializeField] private Material mineMaterial;                 // your units
+[SerializeField] private Material theirsMaterial;               // opponent units
+// unitType (string) -> details, built from the existing 6 SO fields:
+private Dictionary<string, IUnitDetails> detailsByType;
+// rendered units keyed by SERVER unit id, so we can diff broadcasts:
+private readonly Dictionary<string, RenderedUnit> rendered = new();
+private string myPlayerId;
+private int boardW = 32, boardH = 48; // overwritten from welcome/state
+private string selectedUnitType = null; // replaces the 4 placement-mode bools
+```
+where `RenderedUnit` holds `{ GameObject root; UnitDto last; }`.
+
+**`detailsByType` construction** (keep the 6 serialized `*Details` fields; build
+the map in `Awake`):
+```csharp
+detailsByType = new() {
+  ["footman"]    = footmanDetails,
+  ["archer"]     = archerDetails,
+  ["whelp"]      = whelpDetails,
+  ["holyKnight"] = holyKnightDetails,
+  ["barracks"]   = barracksDetails,
+  ["cathedral"]  = cathedralDetails,
+};
+```
+Unknown `unitType` → render a **placeholder** (a tinted primitive cube scaled to
+the catalog footprint) so a server-added unit type never crashes the client.
+
+**Lifecycle:**
+- `Awake()`: build `detailsByType`. If `client == null`, `Debug.LogError` and
+  bail (guided-wiring guard).
+- `Start()`: subscribe
+  `client.WelcomeReceived += OnWelcome;`
+  `client.StateReceived  += OnState;`
+  `client.ErrorReceived  += OnError;`
+  Do **not** call `InitializeBoard()` with hardcoded size or place any starting
+  units. (The server materializes nothing in v1 — starting buildings are M1/M3
+  server-side and not part of v1 `game-server`; the board starts empty, which is
+  correct for "two clients place units.")
+- `OnDestroy()`: unsubscribe.
+
+**`OnWelcome(WelcomeMessage w)`:**
+- `myPlayerId = w.playerId;`
+- If the tile grid isn't built yet, build it from `w.state.board` (`BuildGrid(w.state.board.width, w.state.board.height)`).
+- `RenderState(w.state);`
+
+**`OnState(GameStateDto s)`:**
+- If board dims changed / grid unbuilt, `BuildGrid(s.board.width, s.board.height)`.
+- `RenderState(s);`
+
+**`RenderState(GameStateDto s)` — the reconciler (core algorithm):**
+```
+seen = new HashSet<string>()
+foreach unit in s.units:
+    seen.add(unit.id)
+    if rendered contains unit.id:
+        existing = rendered[unit.id]
+        if existing.last.row != unit.row || col changed || unitType changed:
+            // simplest correct v1: destroy + respawn at new spot
+            Destroy(existing.root); SpawnUnit(unit) → rendered[unit.id]
+        // else unchanged: leave it
+    else:
+        SpawnUnit(unit) → rendered[unit.id]
+// remove units the server no longer reports (sold / owner left)
+foreach id in rendered.keys not in seen:
+    Destroy(rendered[id].root); rendered.remove(id)
+```
+
+**`SpawnUnit(UnitDto u)`** — reuse the existing squad-spawn logic, generalized:
+- Resolve `details = detailsByType.GetValueOrDefault(u.unitType)` (else placeholder path).
+- `bool mine = (u.ownerId == myPlayerId);`
+- Rotation: base `details.ModelRotation`; if `!mine`, pre-multiply
+  `Quaternion.Euler(0,180,0)` (opponent faces you — replaces the old
+  `Player.Player2` branch, now keyed on ownership not a hardcoded enum).
+- Spawn each model of `details.GetSquadFormation()` at
+  `new Vector3(u.row, details.ModelHeight, u.col) + formationOffset + details.ModelPositionOffset`,
+  parented under a `squadParent` GameObject named `{u.ownerId}_{u.unitType}_{u.id}`.
+- **Tint:** apply `mine ? mineMaterial : theirsMaterial` to each model's
+  renderers (or a `MaterialPropertyBlock` color if you'd rather not swap
+  materials). This is the visible ownership coding.
+- Return `new RenderedUnit { root = squadParent, last = u }`.
+
+**Placement input (`Update` → click handler), replacing the 4 bool modes:**
+- The `Toggle*PlacementMode()` methods now just set `selectedUnitType`:
+  ```csharp
+  public void ToggleFootmanPlacementMode()  => selectedUnitType = Flip("footman");
+  public void ToggleArcherPlacementMode()   => selectedUnitType = Flip("archer");
+  public void ToggleWhelpPlacementMode()    => selectedUnitType = Flip("whelp");
+  public void ToggleHolyKnightPlacementMode()=> selectedUnitType = Flip("holyKnight");
+  // Flip(t): returns t if not already selected, else null (toggle off)
+  ```
+- On left-click over a `BoardTile`:
+  ```csharp
+  if (selectedUnitType == null) return;             // just inspecting
+  int row = bt.row, col = bt.col;                   // bt.row=x, bt.col=y
+  client.SendPlaceUnit(selectedUnitType, row, col); // ask the server
+  selectedUnitType = null;                          // one placement per selection
+  // DO NOT spawn locally — wait for the state broadcast
+  ```
+
+**`OnError(ErrorMessage e)`:** `Debug.LogWarning($"[place rejected] {e.code}: {e.message}")`
+and (optional polish) briefly flash the last-clicked tile red. No unit appears —
+correct, because the server sent no state change.
+
+**Delete/retire from `BoardManager`:**
+- Local `tileOccupancy` array + `AreTilesAvailable`/`MarkTilesOccupied`/`ClearTileOccupancy`
+  (server is the authority now).
+- The 4 placement-mode bools.
+- The 4 hardcoded starting-building `PlaceUnit(...)` calls in the old
+  `InitializeBoard`.
+- The old `PlaceUnit(IUnitDetails, Player, x, y)` signature (superseded by
+  `SpawnUnit(UnitDto)`), unless you keep it for an offline mode.
+
+**Keep:** `BuildGrid` (formerly `InitializeBoard`, now parameterized by w/h),
+`GetTile`, the `BoardTile` tag raycast, `ParentTransform`/`BoardTilePrefab`.
+
+---
+
+## 3. Editor wiring checklist (user does)
+
+1. Open `Assets/Scenes/SampleScene.unity`.
+2. Create empty GameObject **`Net`** → Add Component → **GameServerClient**.
+3. On `GameServerClient`: `serverUrl = ws://localhost:7777/ws`,
+   `roomId = lobby`, `playerName = A` (use `B` in the second instance),
+   `connectOnStart = true`.
+4. Select **`_BoardManager`** → drag **`Net`** into the new **Client** field.
+5. Create two simple materials (e.g. teal + clay), assign to **Mine** / **Theirs**.
+6. Confirm the Footman/Archer/Whelp/HolyKnight buttons still point at the
+   `Toggle*PlacementMode` methods (they will — names unchanged).
+
+## 4. Running two clients
+
+```bash
+# 1. start the authoritative server FIRST
+cd apps/game-server && bun run dev        # ws://localhost:7777/ws
+```
+Then two client instances, same `roomId=lobby`:
+- **Simplest:** File → Build (a standalone build), run it, and press Play in the
+  Editor. Two processes.
+- **Zero-build:** Multiplayer Play Mode (`com.unity.multiplayer.center` is
+  installed) → Window → Multiplayer → Multiplayer Play Mode → enable a 2nd
+  virtual player.
+
+## 5. Acceptance criteria
+
+- [ ] Two clients join `lobby` and see the identical set of units.
+- [ ] A places a Footman → within a frame B sees it, tinted as opponent; and the
+      reverse for B.
+- [ ] Placing on an occupied/out-of-bounds tile shows nothing on either client;
+      the placer gets an error log/flash.
+- [ ] Disconnecting one client removes its units from the other's board (the
+      server prunes a departed player and broadcasts).
+- [ ] The placer's own unit appears only after the server confirms (no local
+      pre-spawn).
+
+## 6. Edge cases & how they're handled
+
+| Case | Handling |
+|---|---|
+| Placer clicks twice fast | Each click sends `placeUnit`; server validates each; overlaps rejected. `selectedUnitType=null` after one send prevents accidental double-place from one selection. |
+| Unknown `unitType` from server | `SpawnUnit` placeholder path (tinted cube sized to footprint) — never crashes. |
+| Board size differs from 32×48 later | Grid rebuilt from `state.board`; no hardcoded size remains. |
+| Reconnect / late joiner | `welcome.state` already carries the full `units[]`; `RenderState` builds them all. |
+| Two placements same tile, race | Server serializes per room; second is rejected with `tileOccupied`. |
+| Move (drag) support | Out of scope for v1 shared-placement; if added, `moveUnit` keeps the id so `RenderState` sees a position change and respawns. |
+
+## 7. What this deliberately is NOT
+
+- Not the v2 match loop — no commanders, economy, hidden planning, or battles.
+- No own-half restriction — placement is open across the whole 32×48 board
+  (the v1 server has no deploy-zone check; adding one is a separate server task).
+- No client-side prediction — placement waits for the server round-trip (fine at
+  LAN/local latency; the whole point is a single authoritative truth).
+
+## 8. Commit slices
+
+1. `GameProtocol.cs` comment/semantics (board size from state).
+2. `BoardManager.cs` rewrite: state-driven render + server-routed placement +
+   ownership tint + catalog-size grid; keep `Toggle*` method names.
+3. Docs + this checklist.
+
+No TS/dotnet changes → the existing CI (both jobs) stays green; the feature is
+verified by running the server + two clients per §4–5.
+
+## 9. Effort estimate
+
+- `GameProtocol.cs`: ~10 min (trivial).
+- `BoardManager.cs`: ~2–3 hrs (the reconciler + spawn generalization + input
+  rewrite + material tinting).
+- Editor wiring + first two-client test: ~30 min.
+- Placeholder-unit + tile-flash polish: ~30 min (optional).
+
+Total: **~half a day** to a working two-client shared board, most of it in one
+file, with zero server changes.


### PR DESCRIPTION
## Two-client shared board (server-authoritative rendering)

Implements `docs/two-client-shared-board-plan.md`: two Unity clients in the same
room place units on **one shared, server-authoritative board**, color-coded by
owner, updating live on both screens. The server (`apps/game-server`) is
**unchanged** — it already validates and broadcasts state to the whole room.

### What changed (C# only — no TS/dotnet touched)

- **`BoardManager.cs` — full rewrite** from local placement to a **diff-based
  renderer of server state**:
  - Clicks route through `client.SendPlaceUnit(unitType, row, col)` — **no local
    spawn**; a unit appears only when the server's `state` broadcast comes back.
  - Every unit is rendered from the broadcast, keyed by `unit.id`, and reconciled
    on each broadcast (spawn new / respawn on move·retype·owner-change / despawn
    removed).
  - Ownership tint: `ownerId == myPlayerId` → **Mine** material, else **Theirs**;
    opponent squads face back (rotation keyed on ownership, not the old `Player`
    enum).
  - The tile grid is built from the **server's** board size (`state.board`,
    32×48) — the hardcoded 32×32 is gone. Grid rebuilds if the server ever
    reports different dims.
  - **Unknown `unitType` → tinted footprint-sized placeholder cube**, never
    crashes. Same fallback if a known type has no prefab assigned.
  - Rejected placements (occupied / out-of-bounds) produce no state change, so
    nothing renders; `ErrorReceived` logs the reason for the placer.
- **`GameProtocol.cs`** — the `72×60` constants were stale (server is 32×48 and
  the client now reads the live size from `GameStateDto.board`). Demoted to a
  documented **pre-connect fallback** (set to 32×48) and corrected the board
  convention comment.

### Preserved (hard constraints)

- The four scene-wired methods keep their exact signatures — buttons still work:
  `ToggleFootmanPlacementMode` / `ToggleArcherPlacementMode` /
  `ToggleWhelpPlacementMode` / `ToggleHolyKnightPlacementMode` (now just set the
  selected unit type).
- All serialized `BoardManager` field names the scene references by GUID are
  unchanged: `ParentTransform`, `BoardTilePrefab`, `cathedralDetails`,
  `barracksDetails`, `holyKnightDetails`, `footmanDetails`, `archerDetails`,
  `whelpDetails`. New fields (`client`, `mineMaterial`, `theirsMaterial`) are
  additive and null until wired (below).
- `GameServerClient.cs` — **zero changes** (its API was already sufficient).

### Verification done here (headless)

- **C# compiles clean**: ran Unity 6000.0.32f1's own Roslyn (`csc.dll`) against
  Unity's exact `Assembly-CSharp.rsp` (all 51 game scripts, 297 refs, full Unity
  define set) → **0 errors, 0 warnings**, `Assembly-CSharp.dll` produced.
- **CI green**: `bunx turbo run check-types test build --filter='!battle-server'`
  → 12/12 tasks, game-server 53 pass / 0 fail. `dotnet test dotnet/BoardGame.sln`
  → Core 37 pass, BattleServer 7 pass, 0 failures. (This change touches no
  TS/dotnet; confirmed nothing regressed.)

### Runtime verification: two-client protocol harness

Unity Play mode can't run headless here, so the server-authoritative flow the
BoardManager mirrors is proven with a **4-test integration harness**
(`apps/game-server/src/two-client-shared-board.test.ts`) that drives **two real
WebSocket clients** against the **real game-server** and asserts every §5
acceptance criterion at the wire level:

- both clients join `lobby` and see the identical unit set;
- A places a unit → B receives it with A's `ownerId` (so B tints it "theirs"),
  and symmetrically for B — both broadcasts are byte-identical (no divergence);
- the placer's unit exists **only after** the server confirms (the server
  assigns the id BoardManager keys its diff on — nothing to pre-spawn);
- rejected placements — `tileOccupied`, and off the 32×48 catalog board →
  `outOfBounds` — produce **no** state change on either client;
- disconnecting one client **prunes** its units from the other's board.

This covers everything except the Unity pixels. **57 game-server tests pass**
(was 53). The visual confirmation is the manual two-client run below.

### §3 Editor wiring — automated

`apps/game-client/wire-two-client-scene.py` performs the entire Editor checklist
deterministically (verified against a scene copy — clean YAML merge, idempotent):
it adds the `Net` GameObject + `GameServerClient` (`ws://localhost:7777/ws`, room
`lobby`, name `A`, `connectOnStart`), wires `_BoardManager.client` and the
Mine/Theirs materials, and registers the Transform in SceneRoots. Two URP Lit
materials (`Assets/BoardGame/Materials/{MineUnit,TheirsUnit}.mat`, teal/clay) are
committed for the tint.

> **Run it with the Unity Editor CLOSED** (it edits `SampleScene.unity` on disk;
> a running Editor would overwrite the change on its next save):
> ```bash
> python3 apps/game-client/wire-two-client-scene.py
> ```
> Then reopen the project — the scene is pre-wired. You can still do it by hand
> via the checklist below if you prefer.

### Adversarial review pass + fixes applied

Ran a multi-agent review over the rewrite (reconciler, lifecycle, spawn/tint/grid,
scene-compat) with a follow-up adversarial verification of each finding. Two
confirmed issues were fixed in this branch:

- **Ownership tint had no fallback.** `ApplyTint` only applied a material when
  Mine/Theirs were wired; with them unassigned (they are *not* serialized in the
  shipped scene) mine and theirs rendered identically — defeating the color-coded
  goal during the guided-setup window. Now falls back to a per-renderer
  `MaterialPropertyBlock` colour (teal = mine, clay = theirs) so ownership is
  visible even before you wire the materials. Wiring materials still overrides it.
- **Placeholder cube blocked clicks.** `CreatePrimitive(Cube)` attaches a
  `BoxCollider`; the un-masked placement raycast would hit it before the tile and
  silently swallow the click (only reachable on the unknown-unit-type fallback
  path). The placeholder's collider is now destroyed on spawn.

Lifecycle/`myPlayerId`-timing concerns raised in review were verified and
**refuted**: Unity runs all `OnEnable` (where we subscribe) before any `Update`
(where `GameServerClient` drains its event queue), and the first event is always
`welcome`, which sets `myPlayerId` before the first render — so units never tint
with a stale/null id.

---

## Manual Editor wiring (fallback if you don't run the script above)

The `wire-two-client-scene.py` script does all of this for you. If you'd rather
wire it by hand in the Editor, follow this exactly (plan §3):

1. Open `apps/game-client/Assets/Scenes/SampleScene.unity`.
2. Create an empty GameObject named **`Net`** → **Add Component → GameServerClient**.
3. On the `GameServerClient` component set:
   - `serverUrl` = `ws://localhost:7777/ws`
   - `roomId` = `lobby`
   - `playerName` = `A`  *(use `B` in the second instance — see §Running below)*
   - `connectOnStart` = **on** (checked)
4. Select **`_BoardManager`** → drag the **`Net`** GameObject into the new
   **Client** field.
5. Create two simple materials (e.g. a teal one and a clay/orange one). Assign
   one to BoardManager's **Mine Material** and the other to **Theirs Material**.
   *(Optional: if you leave them empty the units render with their prefab's own
   materials — ownership won't be color-coded, but nothing breaks.)*
6. Confirm the Footman / Archer / Whelp / HolyKnight buttons still point at the
   `Toggle*PlacementMode` methods (they will — names unchanged).
7. Save the scene.

## Running two clients (plan §4)

```bash
# 1) Start the authoritative server FIRST
cd apps/game-server && bun run dev        # ws://localhost:7777/ws
```

Then two client instances in the **same `roomId = lobby`**, with **distinct
`playerName`** (A and B):

- **Simplest:** File → Build a standalone player, run it, and also press ▶ Play
  in the Editor. Two processes → two players.
- **Zero-build:** Window → Multiplayer → **Multiplayer Play Mode**
  (`com.unity.multiplayer.center` is installed) → enable a 2nd virtual player.
  Give the virtual player a different `playerName` (`B`).

## Acceptance criteria to check (plan §5)

- [ ] Two clients join `lobby` and see the identical set of units.
- [ ] A places a Footman → within a frame B sees it, tinted as opponent; and the
      reverse for B.
- [ ] Placing on an occupied / out-of-bounds tile shows nothing on either
      client; the placer gets an error log (`[BoardManager] Placement rejected`).
- [ ] Disconnecting one client removes its units from the other's board (server
      prunes the departed player and broadcasts).
- [ ] The placer's own unit appears only **after** the server confirms (no local
      pre-spawn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
