### PR TITLE
Name the game: Warcaller (Legion Tactics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,14 @@
-# boardgame
+# Warcaller
 
-A multiplayer board game: a Unity client and an authoritative Bun game
-server, organized as a bun-workspaces + Turborepo monorepo.
+**Warcaller: Legion Tactics** — a Mechabellum-style medieval-fantasy
+auto-battler. Two commanders muster squads onto a shared board, spend
+per-round income to reinforce, and watch the battle auto-resolve. Built as a
+Unity client and an authoritative Bun game server, organized as a
+bun-workspaces + Turborepo monorepo.
+
+> Working title. The monorepo package names (`boardgame`, `game-client`,
+> `com.boardgame.core`) are technical identifiers and intentionally left
+> unchanged.
 
 ## Layout
 

--- a/apps/game-client/ProjectSettings/ProjectSettings.asset
+++ b/apps/game-client/ProjectSettings/ProjectSettings.asset
@@ -163,9 +163,9 @@ PlayerSettings:
   androidMaxAspectRatio: 2.4
   androidMinAspectRatio: 1
   applicationIdentifier:
-    Android: com.UnityTechnologies.com.unity.template.urpblank
-    Standalone: com.Unity-Technologies.com.unity.template.urp-blank
-    iPhone: com.Unity-Technologies.com.unity.template.urp-blank
+    Android: gg.warcaller.game
+    Standalone: gg.warcaller.game
+    iPhone: gg.warcaller.game
   buildNumber:
     Standalone: 0
     VisionOS: 0

--- a/apps/game-client/ProjectSettings/ProjectSettings.asset
+++ b/apps/game-client/ProjectSettings/ProjectSettings.asset
@@ -13,7 +13,7 @@ PlayerSettings:
   useOnDemandResources: 0
   accelerometerFrequency: 60
   companyName: DefaultCompany
-  productName: battleship_game
+  productName: 'Warcaller: Legion Tactics'
   defaultCursor: {fileID: 0}
   cursorHotspot: {x: 0, y: 0}
   m_SplashScreenBackgroundColor: {r: 0.13725491, g: 0.12156863, b: 0.1254902, a: 1}


### PR DESCRIPTION
Sets the game's display name to **Warcaller** (working title **Warcaller: Legion Tactics**).

## Changes
- **Unity `productName`**: `battleship_game` → `Warcaller: Legion Tactics` (the app's launcher / title-bar name). Single-quoted in YAML because the value contains a colon; verified it parses back to the exact string. `companyName` left as `DefaultCompany` for now.
- **README**: retitled to Warcaller with a one-line description of the actual game (a Mechabellum-style medieval-fantasy auto-battler).

**Deliberately not renamed:** the technical package identifiers (`boardgame`, `game-client`, `com.boardgame.core`) and workspace names — these are import/reference-bearing and unrelated to the display title.

## Why this name
Chosen after availability research across domains, app stores, and trademarks:
- ✅ **No game** owns the exact title on iOS / Google Play / Steam (Steam search = 0 results).
- ✅ **No "Warcaller" trademark** in software/games (only the differently-spelled, unrelated **WARCOLLAR** cyber-security mark).
- 🟢 `warcaller.gg` / `.io` / `.game` appear **free**; `warcaller.com` is aftermarket (~$3,495 on HugeDomains).
- ⚠️ **Caveat:** "Warcaller" is a common fantasy-lore noun (MTG/WoW/PoE) and there's a phonetically-close live **WarCall.io** — so the subtitle + a strong wordmark carry brand distinctiveness. A formal USPTO clearance is still advisable before commercial commitment (this was a visible-signals check, not legal advice).

## Verification
- `bun run format:check` clean; `bunx turbo run check-types test build --filter='!battle-server'` → 12/12.
- Touches only ProjectSettings + README — no TS/dotnet/C#.

🤖 Generated with [Claude Code](https://claude.com/claude-code)